### PR TITLE
Add GitHub Projects V2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,8 +1132,10 @@ dependencies = [
  "chrono",
  "config",
  "dirs",
+ "indexmap",
  "mockall",
  "octocrab",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1367,18 +1369,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1520,6 +1541,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1530,6 +1553,12 @@ checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
@@ -2387,6 +2416,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "reserve-port"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,6 +3120,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3226,6 +3294,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3622,6 +3700,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +3743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/greport-api/src/main.rs
+++ b/crates/greport-api/src/main.rs
@@ -197,6 +197,23 @@ fn build_router(state: AppState) -> Router {
             "/repos/{owner}/{repo}/sla",
             axum::routing::get(routes::sla::get_sla_report),
         )
+        // Projects
+        .route(
+            "/orgs/{org}/projects",
+            axum::routing::get(routes::projects::list_projects),
+        )
+        .route(
+            "/orgs/{org}/projects/{number}",
+            axum::routing::get(routes::projects::get_project),
+        )
+        .route(
+            "/orgs/{org}/projects/{number}/items",
+            axum::routing::get(routes::projects::list_project_items),
+        )
+        .route(
+            "/orgs/{org}/projects/{number}/metrics",
+            axum::routing::get(routes::projects::get_project_metrics),
+        )
         // Sync
         .route(
             "/repos/{owner}/{repo}/sync",
@@ -244,6 +261,10 @@ fn build_router(state: AppState) -> Router {
         .route(
             "/aggregate/velocity",
             axum::routing::get(routes::aggregate::aggregate_velocity),
+        )
+        .route(
+            "/aggregate/projects",
+            axum::routing::get(routes::projects::aggregate_projects),
         )
         // Cross-org aggregate
         .route(

--- a/crates/greport-api/src/routes/mod.rs
+++ b/crates/greport-api/src/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod contrib;
 pub mod health;
 pub mod issues;
 pub mod orgs;
+pub mod projects;
 pub mod pulls;
 pub mod release_plan;
 pub mod releases;

--- a/crates/greport-api/src/routes/projects.rs
+++ b/crates/greport-api/src/routes/projects.rs
@@ -135,7 +135,9 @@ pub async fn get_project(
 
     let project = greport_db::queries::get_project(pool, &org, number)
         .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Project {} not found for org {}", number, org)))?;
+        .ok_or_else(|| {
+            ApiError::NotFound(format!("Project {} not found for org {}", number, org))
+        })?;
 
     let field_rows = greport_db::queries::list_project_fields(pool, &project.node_id).await?;
     let fields: Vec<ProjectFieldSummary> = field_rows.iter().map(field_row_to_summary).collect();
@@ -168,7 +170,9 @@ pub async fn list_project_items(
 
     let project = greport_db::queries::get_project(pool, &org, number)
         .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Project {} not found for org {}", number, org)))?;
+        .ok_or_else(|| {
+            ApiError::NotFound(format!("Project {} not found for org {}", number, org))
+        })?;
 
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(30).min(100);
@@ -198,8 +202,7 @@ pub async fn list_project_items(
     )
     .await?;
 
-    let response_items: Vec<ProjectItemResponse> =
-        items.iter().map(item_row_to_response).collect();
+    let response_items: Vec<ProjectItemResponse> = items.iter().map(item_row_to_response).collect();
 
     Ok(Json(PaginatedResponse::new(
         response_items,
@@ -221,7 +224,9 @@ pub async fn get_project_metrics(
 
     let project = greport_db::queries::get_project(pool, &org, number)
         .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Project {} not found for org {}", number, org)))?;
+        .ok_or_else(|| {
+            ApiError::NotFound(format!("Project {} not found for org {}", number, org))
+        })?;
 
     // Status breakdown
     let status_rows =
@@ -233,15 +238,9 @@ pub async fn get_project_metrics(
         .collect();
 
     // Content type breakdown
-    let all_items = greport_db::queries::list_project_items(
-        pool,
-        &project.node_id,
-        None,
-        None,
-        None,
-        None,
-    )
-    .await?;
+    let all_items =
+        greport_db::queries::list_project_items(pool, &project.node_id, None, None, None, None)
+            .await?;
 
     let mut type_counts: HashMap<String, i64> = HashMap::new();
     for item in &all_items {
@@ -281,8 +280,7 @@ pub async fn aggregate_projects(
     let mut all_summaries: Vec<ProjectSummary> = Vec::new();
 
     for entry in state.registry.org_entries() {
-        let rows =
-            greport_db::queries::list_projects(pool, &entry.name, include_closed).await?;
+        let rows = greport_db::queries::list_projects(pool, &entry.name, include_closed).await?;
         all_summaries.extend(rows.iter().map(project_row_to_summary));
     }
 

--- a/crates/greport-api/src/routes/projects.rs
+++ b/crates/greport-api/src/routes/projects.rs
@@ -1,0 +1,328 @@
+//! GitHub Projects V2 route handlers
+
+use std::collections::HashMap;
+
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::ApiError;
+use crate::response::{ApiResponse, PaginatedResponse};
+use crate::state::AppState;
+use greport_db::models::{ProjectFieldRow, ProjectItemRow, ProjectRow};
+
+// =============================================================================
+// Response types
+// =============================================================================
+
+#[derive(Serialize)]
+pub struct ProjectSummary {
+    pub number: i64,
+    pub owner: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub closed: bool,
+    pub total_items: i32,
+    pub synced_at: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+pub struct ProjectDetail {
+    pub number: i64,
+    pub owner: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub closed: bool,
+    pub total_items: i32,
+    pub synced_at: DateTime<Utc>,
+    pub fields: Vec<ProjectFieldSummary>,
+}
+
+#[derive(Serialize)]
+pub struct ProjectFieldSummary {
+    pub name: String,
+    pub field_type: String,
+    pub config_json: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct ProjectItemResponse {
+    pub node_id: String,
+    pub content_type: String,
+    pub content_number: Option<i64>,
+    pub content_title: String,
+    pub content_state: Option<String>,
+    pub content_url: Option<String>,
+    pub content_repository: Option<String>,
+    pub field_values: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct ProjectMetrics {
+    pub project_number: i64,
+    pub project_title: String,
+    pub total_items: i32,
+    pub by_status: Vec<StatusCount>,
+    pub by_content_type: Vec<ContentTypeCount>,
+}
+
+#[derive(Serialize)]
+pub struct StatusCount {
+    pub status: String,
+    pub count: i64,
+}
+
+#[derive(Serialize)]
+pub struct ContentTypeCount {
+    pub content_type: String,
+    pub count: i64,
+}
+
+// =============================================================================
+// Query parameter structs
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct ListProjectsQuery {
+    pub include_closed: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct ListItemsQuery {
+    pub content_type: Option<String>,
+    pub state: Option<String>,
+    pub page: Option<u32>,
+    pub per_page: Option<u32>,
+}
+
+// =============================================================================
+// Endpoint handlers
+// =============================================================================
+
+/// GET /api/v1/orgs/{org}/projects
+pub async fn list_projects(
+    State(state): State<AppState>,
+    Path(org): Path<String>,
+    Query(query): Query<ListProjectsQuery>,
+) -> Result<Json<ApiResponse<Vec<ProjectSummary>>>, ApiError> {
+    let pool = state
+        .db
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("Database required for projects".into()))?;
+
+    let include_closed = query.include_closed.unwrap_or(false);
+    let rows = greport_db::queries::list_projects(pool, &org, include_closed).await?;
+    let summaries: Vec<ProjectSummary> = rows.iter().map(project_row_to_summary).collect();
+
+    Ok(Json(ApiResponse::ok(summaries)))
+}
+
+/// GET /api/v1/orgs/{org}/projects/{number}
+pub async fn get_project(
+    State(state): State<AppState>,
+    Path((org, number)): Path<(String, i64)>,
+) -> Result<Json<ApiResponse<ProjectDetail>>, ApiError> {
+    let pool = state
+        .db
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("Database required for projects".into()))?;
+
+    let project = greport_db::queries::get_project(pool, &org, number)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Project {} not found for org {}", number, org)))?;
+
+    let field_rows = greport_db::queries::list_project_fields(pool, &project.node_id).await?;
+    let fields: Vec<ProjectFieldSummary> = field_rows.iter().map(field_row_to_summary).collect();
+
+    let detail = ProjectDetail {
+        number: project.number,
+        owner: project.owner,
+        title: project.title,
+        description: project.description,
+        url: project.url,
+        closed: project.closed,
+        total_items: project.total_items,
+        synced_at: project.synced_at,
+        fields,
+    };
+
+    Ok(Json(ApiResponse::ok(detail)))
+}
+
+/// GET /api/v1/orgs/{org}/projects/{number}/items
+pub async fn list_project_items(
+    State(state): State<AppState>,
+    Path((org, number)): Path<(String, i64)>,
+    Query(query): Query<ListItemsQuery>,
+) -> Result<Json<PaginatedResponse<ProjectItemResponse>>, ApiError> {
+    let pool = state
+        .db
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("Database required for projects".into()))?;
+
+    let project = greport_db::queries::get_project(pool, &org, number)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Project {} not found for org {}", number, org)))?;
+
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(30).min(100);
+    let offset = ((page - 1) * per_page) as i64;
+    let limit = per_page as i64;
+
+    // Get total count (unfiltered by pagination)
+    let all_items = greport_db::queries::list_project_items(
+        pool,
+        &project.node_id,
+        query.content_type.as_deref(),
+        query.state.as_deref(),
+        None,
+        None,
+    )
+    .await?;
+    let total = all_items.len() as u32;
+
+    // Get paginated items
+    let items = greport_db::queries::list_project_items(
+        pool,
+        &project.node_id,
+        query.content_type.as_deref(),
+        query.state.as_deref(),
+        Some(limit),
+        Some(offset),
+    )
+    .await?;
+
+    let response_items: Vec<ProjectItemResponse> =
+        items.iter().map(item_row_to_response).collect();
+
+    Ok(Json(PaginatedResponse::new(
+        response_items,
+        page,
+        per_page,
+        total,
+    )))
+}
+
+/// GET /api/v1/orgs/{org}/projects/{number}/metrics
+pub async fn get_project_metrics(
+    State(state): State<AppState>,
+    Path((org, number)): Path<(String, i64)>,
+) -> Result<Json<ApiResponse<ProjectMetrics>>, ApiError> {
+    let pool = state
+        .db
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("Database required for projects".into()))?;
+
+    let project = greport_db::queries::get_project(pool, &org, number)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Project {} not found for org {}", number, org)))?;
+
+    // Status breakdown
+    let status_rows =
+        greport_db::queries::count_project_items_by_status(pool, &project.node_id, "Status")
+            .await?;
+    let by_status: Vec<StatusCount> = status_rows
+        .into_iter()
+        .map(|(status, count)| StatusCount { status, count })
+        .collect();
+
+    // Content type breakdown
+    let all_items = greport_db::queries::list_project_items(
+        pool,
+        &project.node_id,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    let mut type_counts: HashMap<String, i64> = HashMap::new();
+    for item in &all_items {
+        *type_counts.entry(item.content_type.clone()).or_insert(0) += 1;
+    }
+    let mut by_content_type: Vec<ContentTypeCount> = type_counts
+        .into_iter()
+        .map(|(content_type, count)| ContentTypeCount {
+            content_type,
+            count,
+        })
+        .collect();
+    by_content_type.sort_by(|a, b| b.count.cmp(&a.count));
+
+    let metrics = ProjectMetrics {
+        project_number: project.number,
+        project_title: project.title,
+        total_items: project.total_items,
+        by_status,
+        by_content_type,
+    };
+
+    Ok(Json(ApiResponse::ok(metrics)))
+}
+
+/// GET /api/v1/aggregate/projects
+pub async fn aggregate_projects(
+    State(state): State<AppState>,
+    Query(query): Query<ListProjectsQuery>,
+) -> Result<Json<ApiResponse<Vec<ProjectSummary>>>, ApiError> {
+    let pool = state
+        .db
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("Database required for aggregate projects".into()))?;
+
+    let include_closed = query.include_closed.unwrap_or(false);
+    let mut all_summaries: Vec<ProjectSummary> = Vec::new();
+
+    for entry in state.registry.org_entries() {
+        let rows =
+            greport_db::queries::list_projects(pool, &entry.name, include_closed).await?;
+        all_summaries.extend(rows.iter().map(project_row_to_summary));
+    }
+
+    Ok(Json(ApiResponse::ok(all_summaries)))
+}
+
+// =============================================================================
+// Conversion helpers
+// =============================================================================
+
+fn project_row_to_summary(row: &ProjectRow) -> ProjectSummary {
+    ProjectSummary {
+        number: row.number,
+        owner: row.owner.clone(),
+        title: row.title.clone(),
+        description: row.description.clone(),
+        url: row.url.clone(),
+        closed: row.closed,
+        total_items: row.total_items,
+        synced_at: row.synced_at,
+    }
+}
+
+fn field_row_to_summary(row: &ProjectFieldRow) -> ProjectFieldSummary {
+    ProjectFieldSummary {
+        name: row.name.clone(),
+        field_type: row.field_type.clone(),
+        config_json: row.config_json.clone(),
+    }
+}
+
+fn item_row_to_response(row: &ProjectItemRow) -> ProjectItemResponse {
+    ProjectItemResponse {
+        node_id: row.node_id.clone(),
+        content_type: row.content_type.clone(),
+        content_number: row.content_number,
+        content_title: row.content_title.clone(),
+        content_state: row.content_state.clone(),
+        content_url: row.content_url.clone(),
+        content_repository: row.content_repository.clone(),
+        field_values: row.field_values_json.clone(),
+    }
+}

--- a/crates/greport-api/src/sync.rs
+++ b/crates/greport-api/src/sync.rs
@@ -490,68 +490,75 @@ fn field_to_input(field: &ProjectField, project_id: &str) -> ProjectFieldInput {
 }
 
 fn item_to_input(item: &ProjectItem, project_id: &str) -> ProjectItemInput {
-    let (content_type, content_number, content_title, content_state, content_url, content_repository, content_json) =
-        match &item.content {
-            ProjectItemContent::Issue {
-                number,
-                title,
-                state,
-                url,
-                repository,
-                assignees,
-                labels,
-            } => (
-                "issue".to_string(),
-                Some(*number as i64),
-                title.clone(),
-                Some(state.clone()),
-                Some(url.clone()),
-                Some(repository.clone()),
-                serde_json::to_value(serde_json::json!({
-                    "assignees": assignees,
-                    "labels": labels,
-                }))
-                .ok(),
-            ),
-            ProjectItemContent::PullRequest {
-                number,
-                title,
-                state,
-                url,
-                repository,
-                merged,
-                author,
-            } => (
-                "pull_request".to_string(),
-                Some(*number as i64),
-                title.clone(),
-                Some(state.clone()),
-                Some(url.clone()),
-                Some(repository.clone()),
-                serde_json::to_value(serde_json::json!({
-                    "merged": merged,
-                    "author": author,
-                }))
-                .ok(),
-            ),
-            ProjectItemContent::DraftIssue {
-                title,
-                body,
-                assignees,
-            } => (
-                "draft_issue".to_string(),
-                None,
-                title.clone(),
-                None,
-                None,
-                None,
-                serde_json::to_value(serde_json::json!({
-                    "body": body,
-                    "assignees": assignees,
-                }))
-                .ok(),
-            ),
-        };
+    let (
+        content_type,
+        content_number,
+        content_title,
+        content_state,
+        content_url,
+        content_repository,
+        content_json,
+    ) = match &item.content {
+        ProjectItemContent::Issue {
+            number,
+            title,
+            state,
+            url,
+            repository,
+            assignees,
+            labels,
+        } => (
+            "issue".to_string(),
+            Some(*number as i64),
+            title.clone(),
+            Some(state.clone()),
+            Some(url.clone()),
+            Some(repository.clone()),
+            serde_json::to_value(serde_json::json!({
+                "assignees": assignees,
+                "labels": labels,
+            }))
+            .ok(),
+        ),
+        ProjectItemContent::PullRequest {
+            number,
+            title,
+            state,
+            url,
+            repository,
+            merged,
+            author,
+        } => (
+            "pull_request".to_string(),
+            Some(*number as i64),
+            title.clone(),
+            Some(state.clone()),
+            Some(url.clone()),
+            Some(repository.clone()),
+            serde_json::to_value(serde_json::json!({
+                "merged": merged,
+                "author": author,
+            }))
+            .ok(),
+        ),
+        ProjectItemContent::DraftIssue {
+            title,
+            body,
+            assignees,
+        } => (
+            "draft_issue".to_string(),
+            None,
+            title.clone(),
+            None,
+            None,
+            None,
+            serde_json::to_value(serde_json::json!({
+                "body": body,
+                "assignees": assignees,
+            }))
+            .ok(),
+        ),
+    };
 
     // Serialize field values as a JSON array
     let field_values_json = if item.field_values.is_empty() {

--- a/crates/greport-api/src/sync.rs
+++ b/crates/greport-api/src/sync.rs
@@ -3,11 +3,15 @@
 //! Fetches data from GitHub and upserts it into PostgreSQL.
 
 use chrono::{DateTime, Utc};
-use greport_core::client::{GitHubClient, IssueParams, PullParams, RepoId};
-use greport_core::models::{Issue, Milestone, PullRequest, Release, Repository};
+use greport_core::client::{GitHubClient, IssueParams, ProjectClient, PullParams, RepoId};
+use greport_core::models::{
+    FieldValue, Issue, Milestone, Project, ProjectField, ProjectFieldType, ProjectItem,
+    ProjectItemContent, PullRequest, Release, Repository,
+};
 use greport_core::OctocrabClient;
 use greport_db::models::{
-    IssueInput, MilestoneInput, PullRequestInput, ReleaseInput, RepositoryInput,
+    IssueInput, MilestoneInput, ProjectFieldInput, ProjectInput, ProjectItemInput,
+    PullRequestInput, ReleaseInput, RepositoryInput,
 };
 use greport_db::DbPool;
 use serde::Serialize;
@@ -303,5 +307,313 @@ fn release_to_input(release: &Release, repo_id: i64) -> ReleaseInput {
         author_id: release.author.id,
         created_at: release.created_at,
         published_at: release.published_at,
+    }
+}
+
+// ===========================================================================
+// Project sync
+// ===========================================================================
+
+/// Result of a project sync operation.
+#[derive(Debug, Serialize)]
+pub struct ProjectSyncResult {
+    pub organization: String,
+    pub projects_synced: usize,
+    pub items_synced: usize,
+    pub synced_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// Sync all GitHub Projects V2 data for an organization into the database.
+pub async fn sync_projects(
+    pool: &DbPool,
+    client: &OctocrabClient,
+    org: &str,
+) -> Result<ProjectSyncResult, crate::error::ApiError> {
+    let mut warnings: Vec<String> = vec![];
+    let mut projects_synced = 0usize;
+    let mut items_synced = 0usize;
+
+    // 1. List all projects for the organization
+    let projects = client.list_projects(org).await.map_err(|e| {
+        tracing::error!(org = org, error = ?e, "Failed to list projects");
+        crate::error::ApiError::GitHub(e)
+    })?;
+
+    // Collect current node_ids for stale cleanup
+    let current_node_ids: Vec<String> = projects.iter().map(|p| p.node_id.clone()).collect();
+
+    // 2. For each project: fetch details, fields, items
+    for project_summary in &projects {
+        // Fetch full project with field definitions
+        let project = match client.get_project(org, project_summary.number).await {
+            Ok(p) => p,
+            Err(e) => {
+                let msg = format!(
+                    "Project #{} '{}': {}",
+                    project_summary.number, project_summary.title, e
+                );
+                tracing::warn!(org = org, project = project_summary.number, error = ?e, "Failed to fetch project details, skipping");
+                warnings.push(msg);
+                continue;
+            }
+        };
+
+        // Upsert project metadata
+        let project_input = project_to_input(&project);
+        if let Err(e) = greport_db::queries::upsert_project(pool, &project_input).await {
+            let msg = format!(
+                "Project #{} '{}' upsert: {}",
+                project.number, project.title, e
+            );
+            tracing::warn!(org = org, project = project.number, error = ?e, "Failed to upsert project");
+            warnings.push(msg);
+            continue;
+        }
+
+        // Replace field definitions
+        let field_inputs: Vec<ProjectFieldInput> = project
+            .fields
+            .iter()
+            .map(|f| field_to_input(f, &project.node_id))
+            .collect();
+        if let Err(e) =
+            greport_db::queries::replace_project_fields(pool, &project.node_id, &field_inputs).await
+        {
+            tracing::warn!(org = org, project = project.number, error = ?e, "Failed to replace project fields");
+            warnings.push(format!("Project #{} fields: {}", project.number, e));
+        }
+
+        // Fetch and replace all items
+        match client.list_project_items(&project.node_id).await {
+            Ok(items) => {
+                let item_inputs: Vec<ProjectItemInput> = items
+                    .iter()
+                    .map(|i| item_to_input(i, &project.node_id))
+                    .collect();
+                let item_count = item_inputs.len();
+
+                if let Err(e) =
+                    greport_db::queries::replace_project_items(pool, &project.node_id, &item_inputs)
+                        .await
+                {
+                    tracing::warn!(org = org, project = project.number, error = ?e, "Failed to replace project items");
+                    warnings.push(format!("Project #{} items: {}", project.number, e));
+                } else {
+                    items_synced += item_count;
+                }
+            }
+            Err(e) => {
+                let msg = format!("Project #{} items fetch: {}", project.number, e);
+                tracing::warn!(org = org, project = project.number, error = ?e, "Failed to fetch project items");
+                warnings.push(msg);
+            }
+        }
+
+        projects_synced += 1;
+    }
+
+    // 3. Delete stale projects
+    match greport_db::queries::delete_stale_projects(pool, org, &current_node_ids).await {
+        Ok(deleted) => {
+            if deleted > 0 {
+                tracing::info!(org = org, deleted = deleted, "Removed stale projects");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(org = org, error = ?e, "Failed to clean up stale projects");
+            warnings.push(format!("Stale cleanup: {}", e));
+        }
+    }
+
+    let synced_at = Utc::now();
+    tracing::info!(
+        org = org,
+        projects = projects_synced,
+        items = items_synced,
+        warnings = warnings.len(),
+        "Project sync complete"
+    );
+
+    Ok(ProjectSyncResult {
+        organization: org.to_string(),
+        projects_synced,
+        items_synced,
+        synced_at,
+        warnings,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Core model -> DB input conversions for projects
+// ---------------------------------------------------------------------------
+
+fn project_to_input(project: &Project) -> ProjectInput {
+    ProjectInput {
+        node_id: project.node_id.clone(),
+        number: project.number as i64,
+        owner: project.owner.clone(),
+        title: project.title.clone(),
+        description: project.description.clone(),
+        url: project.url.clone(),
+        closed: project.closed,
+        total_items: project.total_items as i32,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+    }
+}
+
+fn field_to_input(field: &ProjectField, project_id: &str) -> ProjectFieldInput {
+    let (field_type_str, config_json) = match &field.field_type {
+        ProjectFieldType::Text => ("text".to_string(), None),
+        ProjectFieldType::Number => ("number".to_string(), None),
+        ProjectFieldType::Date => ("date".to_string(), None),
+        ProjectFieldType::BuiltIn => ("built_in".to_string(), None),
+        ProjectFieldType::SingleSelect { options } => {
+            let json = serde_json::to_value(options).ok();
+            ("single_select".to_string(), json)
+        }
+        ProjectFieldType::Iteration { iterations } => {
+            let json = serde_json::to_value(iterations).ok();
+            ("iteration".to_string(), json)
+        }
+    };
+
+    ProjectFieldInput {
+        node_id: field.node_id.clone(),
+        project_id: project_id.to_string(),
+        name: field.name.clone(),
+        field_type: field_type_str,
+        config_json,
+    }
+}
+
+fn item_to_input(item: &ProjectItem, project_id: &str) -> ProjectItemInput {
+    let (content_type, content_number, content_title, content_state, content_url, content_repository, content_json) =
+        match &item.content {
+            ProjectItemContent::Issue {
+                number,
+                title,
+                state,
+                url,
+                repository,
+                assignees,
+                labels,
+            } => (
+                "issue".to_string(),
+                Some(*number as i64),
+                title.clone(),
+                Some(state.clone()),
+                Some(url.clone()),
+                Some(repository.clone()),
+                serde_json::to_value(serde_json::json!({
+                    "assignees": assignees,
+                    "labels": labels,
+                }))
+                .ok(),
+            ),
+            ProjectItemContent::PullRequest {
+                number,
+                title,
+                state,
+                url,
+                repository,
+                merged,
+                author,
+            } => (
+                "pull_request".to_string(),
+                Some(*number as i64),
+                title.clone(),
+                Some(state.clone()),
+                Some(url.clone()),
+                Some(repository.clone()),
+                serde_json::to_value(serde_json::json!({
+                    "merged": merged,
+                    "author": author,
+                }))
+                .ok(),
+            ),
+            ProjectItemContent::DraftIssue {
+                title,
+                body,
+                assignees,
+            } => (
+                "draft_issue".to_string(),
+                None,
+                title.clone(),
+                None,
+                None,
+                None,
+                serde_json::to_value(serde_json::json!({
+                    "body": body,
+                    "assignees": assignees,
+                }))
+                .ok(),
+            ),
+        };
+
+    // Serialize field values as a JSON array
+    let field_values_json = if item.field_values.is_empty() {
+        None
+    } else {
+        let values: Vec<serde_json::Value> = item
+            .field_values
+            .iter()
+            .map(|fv| {
+                let mut obj = serde_json::json!({ "field_name": fv.field_name });
+                match &fv.value {
+                    FieldValue::Text { value } => {
+                        obj["type"] = "text".into();
+                        obj["value"] = value.clone().into();
+                    }
+                    FieldValue::Number { value } => {
+                        obj["type"] = "number".into();
+                        obj["value"] = (*value).into();
+                    }
+                    FieldValue::Date { value } => {
+                        obj["type"] = "date".into();
+                        obj["value"] = value.clone().into();
+                    }
+                    FieldValue::SingleSelect { name, option_id } => {
+                        obj["type"] = "single_select".into();
+                        obj["name"] = name.clone().into();
+                        obj["option_id"] = option_id.clone().into();
+                    }
+                    FieldValue::Iteration {
+                        title,
+                        start_date,
+                        duration,
+                        iteration_id,
+                    } => {
+                        obj["type"] = "iteration".into();
+                        obj["title"] = title.clone().into();
+                        obj["start_date"] = start_date.clone().into();
+                        obj["duration"] = (*duration).into();
+                        obj["iteration_id"] = iteration_id.clone().into();
+                    }
+                    FieldValue::Empty => {
+                        obj["type"] = "empty".into();
+                    }
+                }
+                obj
+            })
+            .collect();
+        serde_json::to_value(values).ok()
+    };
+
+    ProjectItemInput {
+        node_id: item.node_id.clone(),
+        project_id: project_id.to_string(),
+        content_type,
+        content_number,
+        content_title,
+        content_state,
+        content_url,
+        content_repository,
+        content_json,
+        field_values_json,
+        created_at: item.created_at,
+        updated_at: item.updated_at,
     }
 }

--- a/crates/greport-core/Cargo.toml
+++ b/crates/greport-core/Cargo.toml
@@ -41,6 +41,12 @@ dirs = "5.0"
 # TOML parsing
 toml = "0.8"
 
+# HTTP client (for GraphQL)
+reqwest = { workspace = true }
+
+# Ordered maps (preserve field option ordering)
+indexmap = { version = "2", features = ["serde"] }
+
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/greport-core/src/client/graphql.rs
+++ b/crates/greport-core/src/client/graphql.rs
@@ -1,0 +1,1366 @@
+//! Lightweight GraphQL client for GitHub Projects V2 API.
+//!
+//! This module provides a thin HTTP wrapper for issuing GraphQL queries
+//! against the GitHub API. It handles authentication, endpoint resolution
+//! (including GitHub Enterprise), and JSON deserialization.
+
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::models::{
+    FieldValue, IterationValue, LabelInfo, Project, ProjectField, ProjectFieldType,
+    ProjectFieldValue, ProjectItem, ProjectItemContent, SelectOption,
+};
+use crate::{Error, Result};
+
+// ---------------------------------------------------------------------------
+// GraphQL query constants
+// ---------------------------------------------------------------------------
+
+/// List all projects for an organization.
+const LIST_ORG_PROJECTS: &str = r#"
+query($org: String!, $first: Int!, $after: String) {
+  organization(login: $org) {
+    projectsV2(first: $first, after: $after, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        id
+        number
+        title
+        shortDescription
+        url
+        closed
+        createdAt
+        updatedAt
+        items { totalCount }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"#;
+
+/// Get a single project with field definitions.
+const GET_PROJECT_WITH_FIELDS: &str = r#"
+query($org: String!, $number: Int!) {
+  organization(login: $org) {
+    projectV2(number: $number) {
+      id
+      number
+      title
+      shortDescription
+      url
+      closed
+      createdAt
+      updatedAt
+      items { totalCount }
+      fields(first: 30) {
+        nodes {
+          ... on ProjectV2FieldCommon {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options {
+              id
+              name
+              color
+              description
+            }
+          }
+          ... on ProjectV2IterationField {
+            id
+            name
+            dataType
+            configuration {
+              iterations {
+                id
+                title
+                startDate
+                duration
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// List items in a project (paginated).
+const LIST_PROJECT_ITEMS: &str = r#"
+query($nodeId: ID!, $first: Int!, $after: String) {
+  node(id: $nodeId) {
+    ... on ProjectV2 {
+      items(first: $first, after: $after) {
+        nodes {
+          id
+          createdAt
+          updatedAt
+          content {
+            ... on Issue {
+              number
+              title
+              state
+              url
+              repository { nameWithOwner }
+              assignees(first: 10) { nodes { login } }
+              labels(first: 10) { nodes { name color } }
+            }
+            ... on PullRequest {
+              number
+              title
+              state
+              url
+              merged
+              repository { nameWithOwner }
+              author { login }
+            }
+            ... on DraftIssue {
+              title
+              body
+              assignees(first: 10) { nodes { login } }
+            }
+          }
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldDateValue {
+                date
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                optionId
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldIterationValue {
+                title
+                startDate
+                duration
+                iterationId
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Endpoint resolution
+// ---------------------------------------------------------------------------
+
+/// Derive the GraphQL endpoint URL from an optional REST API base URL.
+///
+/// Resolution rules:
+///   None                            -> https://api.github.com/graphql
+///   https://ghe.co/api/v3          -> https://ghe.co/api/graphql
+///   https://ghe.co/api             -> https://ghe.co/api/graphql
+///   https://ghe.co                 -> https://ghe.co/api/graphql
+pub fn derive_graphql_url(base_url: Option<&str>) -> String {
+    match base_url {
+        None => "https://api.github.com/graphql".to_string(),
+        Some(url) => {
+            let trimmed = url.trim_end_matches('/');
+            let base = trimmed
+                .strip_suffix("/api/v3")
+                .or_else(|| trimmed.strip_suffix("/api"))
+                .unwrap_or(trimmed);
+            format!("{}/api/graphql", base)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL client
+// ---------------------------------------------------------------------------
+
+/// Lightweight GraphQL client for GitHub APIs.
+pub struct GraphQLClient {
+    http: Client,
+    endpoint: String,
+    token: String,
+}
+
+impl std::fmt::Debug for GraphQLClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GraphQLClient")
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Serialize)]
+struct GraphQLRequest<'a> {
+    query: &'a str,
+    variables: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct GraphQLResponse<T> {
+    data: Option<T>,
+    errors: Option<Vec<GraphQLError>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLError {
+    message: String,
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    error_type: Option<String>,
+}
+
+impl GraphQLClient {
+    /// Create a new GraphQL client.
+    pub fn new(token: &str, base_url: Option<&str>) -> Result<Self> {
+        let endpoint = derive_graphql_url(base_url);
+        debug!(endpoint = %endpoint, "Creating GraphQL client");
+
+        let http = Client::builder()
+            .user_agent("greport")
+            .build()
+            .map_err(|e| Error::Custom(format!("Failed to create HTTP client: {}", e)))?;
+
+        Ok(Self {
+            http,
+            endpoint,
+            token: token.to_string(),
+        })
+    }
+
+    /// Execute a GraphQL query and deserialize the response.
+    pub async fn query<T: DeserializeOwned>(
+        &self,
+        query: &str,
+        variables: serde_json::Value,
+    ) -> Result<T> {
+        let request_body = GraphQLRequest { query, variables };
+
+        let response = self
+            .http
+            .post(&self.endpoint)
+            .header("Authorization", format!("bearer {}", self.token))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| Error::Network(format!("GraphQL request failed: {}", e)))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::GraphQL(format!(
+                "HTTP {}: {}",
+                status.as_u16(),
+                body
+            )));
+        }
+
+        let gql_response: GraphQLResponse<T> = response
+            .json()
+            .await
+            .map_err(|e| Error::GraphQL(format!("Failed to parse GraphQL response: {}", e)))?;
+
+        if let Some(errors) = gql_response.errors {
+            if !errors.is_empty() {
+                return Err(classify_graphql_errors(&errors));
+            }
+        }
+
+        gql_response
+            .data
+            .ok_or_else(|| Error::GraphQL("GraphQL response contained no data".to_string()))
+    }
+
+    // -----------------------------------------------------------------------
+    // High-level project operations
+    // -----------------------------------------------------------------------
+
+    /// List all projects for an organization.
+    pub async fn list_org_projects(&self, org: &str) -> Result<Vec<Project>> {
+        let mut all_projects = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let variables = serde_json::json!({
+                "org": org,
+                "first": 100,
+                "after": cursor,
+            });
+
+            let data: OrgProjectsData = self.query(LIST_ORG_PROJECTS, variables).await?;
+            let connection = data.organization.projects_v2;
+
+            for node in connection.nodes {
+                all_projects.push(convert_project_summary(node, org));
+            }
+
+            if connection.page_info.has_next_page {
+                cursor = connection.page_info.end_cursor;
+            } else {
+                break;
+            }
+        }
+
+        debug!(org = org, count = all_projects.len(), "Fetched projects");
+        Ok(all_projects)
+    }
+
+    /// Get a single project with field definitions.
+    pub async fn get_project_detail(
+        &self,
+        org: &str,
+        project_number: u64,
+    ) -> Result<Project> {
+        let variables = serde_json::json!({
+            "org": org,
+            "number": project_number as i64,
+        });
+
+        let data: OrgProjectDetailData = self.query(GET_PROJECT_WITH_FIELDS, variables).await?;
+        let gql_project = data.organization.project_v2.ok_or_else(|| {
+            Error::NotFound(format!("Project #{} not found in org '{}'", project_number, org))
+        })?;
+
+        let fields = gql_project
+            .fields
+            .as_ref()
+            .map(|f| f.nodes.iter().map(convert_field).collect())
+            .unwrap_or_default();
+
+        let mut project = convert_project_summary(
+            GqlProject {
+                id: gql_project.id,
+                number: gql_project.number,
+                title: gql_project.title,
+                short_description: gql_project.short_description,
+                url: gql_project.url,
+                closed: gql_project.closed,
+                created_at: gql_project.created_at,
+                updated_at: gql_project.updated_at,
+                items: gql_project.items,
+            },
+            org,
+        );
+        project.fields = fields;
+
+        Ok(project)
+    }
+
+    /// List all items in a project (handles pagination).
+    pub async fn list_items(&self, project_node_id: &str) -> Result<Vec<ProjectItem>> {
+        let mut all_items = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let variables = serde_json::json!({
+                "nodeId": project_node_id,
+                "first": 100,
+                "after": cursor,
+            });
+
+            let data: NodeItemsData = self.query(LIST_PROJECT_ITEMS, variables).await?;
+            let project_data = data.node.ok_or_else(|| {
+                Error::NotFound(format!("Project node '{}' not found", project_node_id))
+            })?;
+
+            let connection = project_data.items;
+
+            for node in connection.nodes {
+                if let Some(item) = convert_item(node) {
+                    all_items.push(item);
+                }
+            }
+
+            if connection.page_info.has_next_page {
+                cursor = connection.page_info.end_cursor;
+            } else {
+                break;
+            }
+        }
+
+        debug!(
+            project = project_node_id,
+            count = all_items.len(),
+            "Fetched project items"
+        );
+        Ok(all_items)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/// Classify GraphQL errors into typed Error variants.
+fn classify_graphql_errors(errors: &[GraphQLError]) -> Error {
+    for err in errors {
+        let msg = &err.message;
+        let msg_lower = msg.to_lowercase();
+
+        // Permission errors
+        if msg_lower.contains("resource not accessible by personal access token")
+            || msg_lower.contains("read:project")
+            || msg_lower.contains("insufficient scopes")
+        {
+            return Error::MissingProjectScope {
+                org: "unknown".to_string(),
+            };
+        }
+
+        // Not found
+        if msg_lower.contains("could not resolve to") {
+            return Error::NotFound(msg.clone());
+        }
+
+        // GHES version too old
+        if msg_lower.contains("projectsv2") && msg_lower.contains("doesn't exist") {
+            return Error::ProjectsNotAvailable;
+        }
+    }
+
+    // Generic fallback
+    let messages: Vec<&str> = errors.iter().map(|e| e.message.as_str()).collect();
+    Error::GraphQL(messages.join("; "))
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL response types (private serde structs)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    end_cursor: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Connection<T> {
+    nodes: Vec<T>,
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+}
+
+#[derive(Clone, Deserialize)]
+struct TotalCount {
+    #[serde(rename = "totalCount")]
+    total_count: u32,
+}
+
+// -- List projects response --
+
+#[derive(Deserialize)]
+struct OrgProjectsData {
+    organization: OrgProjectsOrg,
+}
+
+#[derive(Deserialize)]
+struct OrgProjectsOrg {
+    #[serde(rename = "projectsV2")]
+    projects_v2: Connection<GqlProject>,
+}
+
+#[derive(Clone, Deserialize)]
+struct GqlProject {
+    id: String,
+    number: u64,
+    title: String,
+    #[serde(rename = "shortDescription")]
+    short_description: Option<String>,
+    url: String,
+    closed: bool,
+    #[serde(rename = "createdAt")]
+    created_at: DateTime<Utc>,
+    #[serde(rename = "updatedAt")]
+    updated_at: DateTime<Utc>,
+    items: Option<TotalCount>,
+}
+
+// -- Get project detail response --
+
+#[derive(Deserialize)]
+struct OrgProjectDetailData {
+    organization: OrgProjectDetailOrg,
+}
+
+#[derive(Deserialize)]
+struct OrgProjectDetailOrg {
+    #[serde(rename = "projectV2")]
+    project_v2: Option<GqlProjectDetail>,
+}
+
+#[derive(Deserialize)]
+struct GqlProjectDetail {
+    id: String,
+    number: u64,
+    title: String,
+    #[serde(rename = "shortDescription")]
+    short_description: Option<String>,
+    url: String,
+    closed: bool,
+    #[serde(rename = "createdAt")]
+    created_at: DateTime<Utc>,
+    #[serde(rename = "updatedAt")]
+    updated_at: DateTime<Utc>,
+    items: Option<TotalCount>,
+    fields: Option<FieldsConnection>,
+}
+
+#[derive(Deserialize)]
+struct FieldsConnection {
+    nodes: Vec<GqlField>,
+}
+
+#[derive(Deserialize)]
+struct GqlField {
+    id: Option<String>,
+    name: Option<String>,
+    #[serde(rename = "dataType")]
+    data_type: Option<String>,
+    options: Option<Vec<GqlSelectOption>>,
+    configuration: Option<GqlIterationConfig>,
+}
+
+#[derive(Deserialize)]
+struct GqlSelectOption {
+    id: String,
+    name: String,
+    color: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GqlIterationConfig {
+    iterations: Vec<GqlIteration>,
+}
+
+#[derive(Deserialize)]
+struct GqlIteration {
+    id: String,
+    title: String,
+    #[serde(rename = "startDate")]
+    start_date: String,
+    duration: u32,
+}
+
+// -- List items response --
+
+#[derive(Deserialize)]
+struct NodeItemsData {
+    node: Option<GqlProjectNode>,
+}
+
+#[derive(Deserialize)]
+struct GqlProjectNode {
+    items: Connection<GqlItem>,
+}
+
+#[derive(Deserialize)]
+struct GqlItem {
+    id: String,
+    #[serde(rename = "createdAt")]
+    created_at: DateTime<Utc>,
+    #[serde(rename = "updatedAt")]
+    updated_at: DateTime<Utc>,
+    content: Option<GqlItemContent>,
+    #[serde(rename = "fieldValues")]
+    field_values: Option<GqlFieldValuesConnection>,
+}
+
+/// The content union -- GitHub returns different shapes based on type.
+/// We use flatten + Options to handle the union.
+#[derive(Deserialize)]
+struct GqlItemContent {
+    // Common to Issue and PR
+    number: Option<u64>,
+    title: Option<String>,
+    state: Option<String>,
+    url: Option<String>,
+    repository: Option<GqlRepo>,
+    // Issue-specific
+    assignees: Option<GqlLoginNodes>,
+    labels: Option<GqlLabelNodes>,
+    // PR-specific
+    merged: Option<bool>,
+    author: Option<GqlLogin>,
+    // DraftIssue-specific
+    body: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GqlRepo {
+    #[serde(rename = "nameWithOwner")]
+    name_with_owner: String,
+}
+
+#[derive(Deserialize)]
+struct GqlLoginNodes {
+    nodes: Vec<GqlLogin>,
+}
+
+#[derive(Deserialize)]
+struct GqlLogin {
+    login: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GqlLabelNodes {
+    nodes: Vec<GqlLabel>,
+}
+
+#[derive(Deserialize)]
+struct GqlLabel {
+    name: String,
+    color: String,
+}
+
+#[derive(Deserialize)]
+struct GqlFieldValuesConnection {
+    nodes: Vec<GqlFieldValueNode>,
+}
+
+/// Field value node -- union type handled via Options.
+#[derive(Deserialize)]
+struct GqlFieldValueNode {
+    // Text
+    text: Option<String>,
+    // Number
+    number: Option<f64>,
+    // Date
+    date: Option<String>,
+    // SingleSelect
+    name: Option<String>,
+    #[serde(rename = "optionId")]
+    option_id: Option<String>,
+    // Iteration
+    title: Option<String>,
+    #[serde(rename = "startDate")]
+    start_date: Option<String>,
+    duration: Option<u32>,
+    #[serde(rename = "iterationId")]
+    iteration_id: Option<String>,
+    // Common
+    field: Option<GqlFieldRef>,
+}
+
+#[derive(Deserialize)]
+struct GqlFieldRef {
+    name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Conversion functions (GraphQL response -> domain models)
+// ---------------------------------------------------------------------------
+
+fn convert_project_summary(gql: GqlProject, org: &str) -> Project {
+    Project {
+        node_id: gql.id,
+        number: gql.number,
+        title: gql.title,
+        description: gql.short_description,
+        url: gql.url,
+        closed: gql.closed,
+        owner: org.to_string(),
+        created_at: gql.created_at,
+        updated_at: gql.updated_at,
+        fields: Vec::new(),
+        total_items: gql.items.map(|i| i.total_count).unwrap_or(0),
+    }
+}
+
+fn convert_field(gql: &GqlField) -> ProjectField {
+    let node_id = gql.id.clone().unwrap_or_default();
+    let name = gql.name.clone().unwrap_or_default();
+    let data_type = gql.data_type.as_deref().unwrap_or("");
+
+    let field_type = match data_type {
+        "TEXT" => ProjectFieldType::Text,
+        "NUMBER" => ProjectFieldType::Number,
+        "DATE" => ProjectFieldType::Date,
+        "SINGLE_SELECT" => {
+            let options = gql
+                .options
+                .as_ref()
+                .map(|opts| {
+                    opts.iter()
+                        .map(|o| SelectOption {
+                            id: o.id.clone(),
+                            name: o.name.clone(),
+                            color: o.color.clone(),
+                            description: o.description.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            ProjectFieldType::SingleSelect { options }
+        }
+        "ITERATION" => {
+            let iterations = gql
+                .configuration
+                .as_ref()
+                .map(|cfg| {
+                    cfg.iterations
+                        .iter()
+                        .map(|it| IterationValue {
+                            id: it.id.clone(),
+                            title: it.title.clone(),
+                            start_date: it.start_date.clone(),
+                            duration: it.duration,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            ProjectFieldType::Iteration { iterations }
+        }
+        "TITLE" | "ASSIGNEES" | "LABELS" | "MILESTONE" | "REPOSITORY" | "REVIEWERS"
+        | "LINKED_PULL_REQUESTS" | "TRACKS" | "TRACKED_BY" => ProjectFieldType::BuiltIn,
+        _ => {
+            warn!(data_type = data_type, name = %name, "Unknown field type, treating as BuiltIn");
+            ProjectFieldType::BuiltIn
+        }
+    };
+
+    ProjectField {
+        node_id,
+        name,
+        field_type,
+    }
+}
+
+fn convert_item(gql: GqlItem) -> Option<ProjectItem> {
+    let content = match gql.content {
+        Some(c) => convert_content(c)?,
+        None => return None,
+    };
+
+    let field_values = gql
+        .field_values
+        .map(|fv| {
+            fv.nodes
+                .into_iter()
+                .filter_map(convert_field_value)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(ProjectItem {
+        node_id: gql.id,
+        content,
+        field_values,
+        created_at: gql.created_at,
+        updated_at: gql.updated_at,
+    })
+}
+
+fn convert_content(gql: GqlItemContent) -> Option<ProjectItemContent> {
+    // Determine content type by which fields are present
+    if let Some(repo) = &gql.repository {
+        // Has a repository -> Issue or PR
+        if gql.merged.is_some() {
+            // PR (has merged field)
+            Some(ProjectItemContent::PullRequest {
+                number: gql.number.unwrap_or(0),
+                title: gql.title.unwrap_or_default(),
+                state: gql.state.unwrap_or_default(),
+                url: gql.url.unwrap_or_default(),
+                repository: repo.name_with_owner.clone(),
+                merged: gql.merged.unwrap_or(false),
+                author: gql
+                    .author
+                    .and_then(|a| a.login)
+                    .unwrap_or_else(|| "unknown".to_string()),
+            })
+        } else {
+            // Issue
+            let assignees = gql
+                .assignees
+                .map(|a| a.nodes.into_iter().filter_map(|n| n.login).collect())
+                .unwrap_or_default();
+            let labels = gql
+                .labels
+                .map(|l| {
+                    l.nodes
+                        .into_iter()
+                        .map(|n| LabelInfo {
+                            name: n.name,
+                            color: n.color,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Some(ProjectItemContent::Issue {
+                number: gql.number.unwrap_or(0),
+                title: gql.title.unwrap_or_default(),
+                state: gql.state.unwrap_or_default(),
+                url: gql.url.unwrap_or_default(),
+                repository: repo.name_with_owner.clone(),
+                assignees,
+                labels,
+            })
+        }
+    } else if gql.title.is_some() {
+        // No repository -> DraftIssue
+        let assignees = gql
+            .assignees
+            .map(|a| a.nodes.into_iter().filter_map(|n| n.login).collect())
+            .unwrap_or_default();
+
+        Some(ProjectItemContent::DraftIssue {
+            title: gql.title.unwrap_or_default(),
+            body: gql.body,
+            assignees,
+        })
+    } else {
+        // Empty or redacted content
+        None
+    }
+}
+
+fn convert_field_value(gql: GqlFieldValueNode) -> Option<ProjectFieldValue> {
+    let field_name = gql.field.as_ref()?.name.as_ref()?.clone();
+
+    // Determine value type by which fields are populated.
+    // Order matters: check iteration first (has title + startDate + duration),
+    // then single-select (has name + optionId), then simpler types.
+
+    let value = if gql.iteration_id.is_some() {
+        FieldValue::Iteration {
+            title: gql.title.unwrap_or_default(),
+            start_date: gql.start_date.unwrap_or_default(),
+            duration: gql.duration.unwrap_or(0),
+            iteration_id: gql.iteration_id.unwrap_or_default(),
+        }
+    } else if gql.option_id.is_some() {
+        FieldValue::SingleSelect {
+            name: gql.name.unwrap_or_default(),
+            option_id: gql.option_id.unwrap_or_default(),
+        }
+    } else if let Some(text) = gql.text {
+        FieldValue::Text { value: text }
+    } else if let Some(num) = gql.number {
+        FieldValue::Number { value: num }
+    } else if let Some(date) = gql.date {
+        FieldValue::Date { value: date }
+    } else {
+        // Empty or unrecognized field value type
+        return None;
+    };
+
+    Some(ProjectFieldValue { field_name, value })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- derive_graphql_url tests --
+
+    #[test]
+    fn test_derive_graphql_url_github_com() {
+        assert_eq!(
+            derive_graphql_url(None),
+            "https://api.github.com/graphql"
+        );
+    }
+
+    #[test]
+    fn test_derive_graphql_url_ghe_api_v3() {
+        assert_eq!(
+            derive_graphql_url(Some("https://ghe.corp.com/api/v3")),
+            "https://ghe.corp.com/api/graphql"
+        );
+    }
+
+    #[test]
+    fn test_derive_graphql_url_ghe_api_v3_trailing_slash() {
+        assert_eq!(
+            derive_graphql_url(Some("https://ghe.corp.com/api/v3/")),
+            "https://ghe.corp.com/api/graphql"
+        );
+    }
+
+    #[test]
+    fn test_derive_graphql_url_ghe_api() {
+        assert_eq!(
+            derive_graphql_url(Some("https://ghe.corp.com/api")),
+            "https://ghe.corp.com/api/graphql"
+        );
+    }
+
+    #[test]
+    fn test_derive_graphql_url_bare_hostname() {
+        assert_eq!(
+            derive_graphql_url(Some("https://ghe.corp.com")),
+            "https://ghe.corp.com/api/graphql"
+        );
+    }
+
+    // -- Response parsing tests --
+
+    #[test]
+    fn test_parse_projects_response() {
+        let json = r#"{
+            "data": {
+                "organization": {
+                    "projectsV2": {
+                        "nodes": [
+                            {
+                                "id": "PVT_kwDOABC",
+                                "number": 5,
+                                "title": "Sprint Q1",
+                                "shortDescription": "Q1 planning",
+                                "url": "https://github.com/orgs/my-org/projects/5",
+                                "closed": false,
+                                "createdAt": "2026-01-15T10:00:00Z",
+                                "updatedAt": "2026-02-10T14:30:00Z",
+                                "items": { "totalCount": 47 }
+                            },
+                            {
+                                "id": "PVT_kwDODEF",
+                                "number": 4,
+                                "title": "Infra Upgrades",
+                                "shortDescription": null,
+                                "url": "https://github.com/orgs/my-org/projects/4",
+                                "closed": true,
+                                "createdAt": "2025-11-01T08:00:00Z",
+                                "updatedAt": "2026-01-30T12:00:00Z",
+                                "items": { "totalCount": 23 }
+                            }
+                        ],
+                        "pageInfo": {
+                            "hasNextPage": false,
+                            "endCursor": null
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let resp: GraphQLResponse<OrgProjectsData> = serde_json::from_str(json).unwrap();
+        let data = resp.data.unwrap();
+        let nodes = &data.organization.projects_v2.nodes;
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].number, 5);
+        assert_eq!(nodes[0].title, "Sprint Q1");
+        assert!(!nodes[0].closed);
+        assert_eq!(nodes[0].items.as_ref().unwrap().total_count, 47);
+        assert_eq!(nodes[1].number, 4);
+        assert!(nodes[1].closed);
+
+        // Test conversion
+        let project = convert_project_summary(nodes[0].clone(), "my-org");
+        assert_eq!(project.owner, "my-org");
+        assert_eq!(project.total_items, 47);
+        assert_eq!(project.node_id, "PVT_kwDOABC");
+    }
+
+    #[test]
+    fn test_parse_project_with_fields() {
+        let json = r#"{
+            "data": {
+                "organization": {
+                    "projectV2": {
+                        "id": "PVT_kwDOABC",
+                        "number": 5,
+                        "title": "Sprint Q1",
+                        "shortDescription": null,
+                        "url": "https://github.com/orgs/my-org/projects/5",
+                        "closed": false,
+                        "createdAt": "2026-01-15T10:00:00Z",
+                        "updatedAt": "2026-02-10T14:30:00Z",
+                        "items": { "totalCount": 47 },
+                        "fields": {
+                            "nodes": [
+                                {
+                                    "id": "PVTF_title",
+                                    "name": "Title",
+                                    "dataType": "TITLE"
+                                },
+                                {
+                                    "id": "PVTSSF_status",
+                                    "name": "Status",
+                                    "dataType": "SINGLE_SELECT",
+                                    "options": [
+                                        { "id": "opt1", "name": "Todo", "color": "GRAY", "description": null },
+                                        { "id": "opt2", "name": "In Progress", "color": "YELLOW", "description": null },
+                                        { "id": "opt3", "name": "Done", "color": "GREEN", "description": null }
+                                    ]
+                                },
+                                {
+                                    "id": "PVTIF_sprint",
+                                    "name": "Sprint",
+                                    "dataType": "ITERATION",
+                                    "configuration": {
+                                        "iterations": [
+                                            { "id": "it1", "title": "Sprint 1", "startDate": "2026-01-06", "duration": 14 },
+                                            { "id": "it2", "title": "Sprint 2", "startDate": "2026-01-20", "duration": 14 }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "PVTF_pts",
+                                    "name": "Story Points",
+                                    "dataType": "NUMBER"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let resp: GraphQLResponse<OrgProjectDetailData> = serde_json::from_str(json).unwrap();
+        let data = resp.data.unwrap();
+        let project = data.organization.project_v2.unwrap();
+        let fields: Vec<ProjectField> = project
+            .fields
+            .as_ref()
+            .unwrap()
+            .nodes
+            .iter()
+            .map(convert_field)
+            .collect();
+
+        assert_eq!(fields.len(), 4);
+
+        // Title -> BuiltIn
+        assert_eq!(fields[0].name, "Title");
+        assert!(matches!(fields[0].field_type, ProjectFieldType::BuiltIn));
+
+        // Status -> SingleSelect with 3 options
+        assert_eq!(fields[1].name, "Status");
+        match &fields[1].field_type {
+            ProjectFieldType::SingleSelect { options } => {
+                assert_eq!(options.len(), 3);
+                assert_eq!(options[0].name, "Todo");
+                assert_eq!(options[1].name, "In Progress");
+                assert_eq!(options[2].name, "Done");
+            }
+            other => panic!("Expected SingleSelect, got {:?}", other),
+        }
+
+        // Sprint -> Iteration with 2 iterations
+        assert_eq!(fields[2].name, "Sprint");
+        match &fields[2].field_type {
+            ProjectFieldType::Iteration { iterations } => {
+                assert_eq!(iterations.len(), 2);
+                assert_eq!(iterations[0].title, "Sprint 1");
+                assert_eq!(iterations[0].duration, 14);
+                assert_eq!(iterations[1].title, "Sprint 2");
+            }
+            other => panic!("Expected Iteration, got {:?}", other),
+        }
+
+        // Story Points -> Number
+        assert_eq!(fields[3].name, "Story Points");
+        assert!(matches!(fields[3].field_type, ProjectFieldType::Number));
+    }
+
+    #[test]
+    fn test_parse_project_items() {
+        let json = r#"{
+            "data": {
+                "node": {
+                    "items": {
+                        "nodes": [
+                            {
+                                "id": "PVTI_issue",
+                                "createdAt": "2026-01-20T09:00:00Z",
+                                "updatedAt": "2026-02-08T16:00:00Z",
+                                "content": {
+                                    "number": 42,
+                                    "title": "Implement auth",
+                                    "state": "OPEN",
+                                    "url": "https://github.com/my-org/repo/issues/42",
+                                    "repository": { "nameWithOwner": "my-org/repo" },
+                                    "assignees": { "nodes": [{ "login": "alice" }, { "login": "bob" }] },
+                                    "labels": { "nodes": [{ "name": "feature", "color": "0e8a16" }] }
+                                },
+                                "fieldValues": {
+                                    "nodes": [
+                                        {
+                                            "name": "In Progress",
+                                            "optionId": "opt2",
+                                            "field": { "name": "Status" }
+                                        },
+                                        {
+                                            "number": 5.0,
+                                            "field": { "name": "Story Points" }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "PVTI_pr",
+                                "createdAt": "2026-01-22T10:00:00Z",
+                                "updatedAt": "2026-02-09T11:00:00Z",
+                                "content": {
+                                    "number": 100,
+                                    "title": "Fix login bug",
+                                    "state": "MERGED",
+                                    "url": "https://github.com/my-org/repo/pull/100",
+                                    "merged": true,
+                                    "repository": { "nameWithOwner": "my-org/repo" },
+                                    "author": { "login": "charlie" }
+                                },
+                                "fieldValues": {
+                                    "nodes": [
+                                        {
+                                            "name": "Done",
+                                            "optionId": "opt3",
+                                            "field": { "name": "Status" }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "PVTI_draft",
+                                "createdAt": "2026-02-01T08:00:00Z",
+                                "updatedAt": "2026-02-01T08:00:00Z",
+                                "content": {
+                                    "title": "Research caching",
+                                    "body": "Investigate Redis vs Memcached",
+                                    "assignees": { "nodes": [{ "login": "alice" }] }
+                                },
+                                "fieldValues": {
+                                    "nodes": []
+                                }
+                            }
+                        ],
+                        "pageInfo": {
+                            "hasNextPage": false,
+                            "endCursor": null
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let resp: GraphQLResponse<NodeItemsData> = serde_json::from_str(json).unwrap();
+        let data = resp.data.unwrap();
+        let items_conn = data.node.unwrap().items;
+        let items: Vec<ProjectItem> = items_conn
+            .nodes
+            .into_iter()
+            .filter_map(convert_item)
+            .collect();
+
+        assert_eq!(items.len(), 3);
+
+        // First item: Issue
+        match &items[0].content {
+            ProjectItemContent::Issue {
+                number,
+                title,
+                state,
+                repository,
+                assignees,
+                labels,
+                ..
+            } => {
+                assert_eq!(*number, 42);
+                assert_eq!(title, "Implement auth");
+                assert_eq!(state, "OPEN");
+                assert_eq!(repository, "my-org/repo");
+                assert_eq!(assignees, &["alice", "bob"]);
+                assert_eq!(labels.len(), 1);
+                assert_eq!(labels[0].name, "feature");
+            }
+            other => panic!("Expected Issue, got {:?}", other),
+        }
+        assert_eq!(items[0].field_values.len(), 2);
+        assert_eq!(items[0].field_values[0].field_name, "Status");
+        match &items[0].field_values[0].value {
+            FieldValue::SingleSelect { name, .. } => assert_eq!(name, "In Progress"),
+            other => panic!("Expected SingleSelect, got {:?}", other),
+        }
+        match &items[0].field_values[1].value {
+            FieldValue::Number { value } => assert!((value - 5.0).abs() < f64::EPSILON),
+            other => panic!("Expected Number, got {:?}", other),
+        }
+
+        // Second item: PR
+        match &items[1].content {
+            ProjectItemContent::PullRequest {
+                number,
+                title,
+                merged,
+                author,
+                ..
+            } => {
+                assert_eq!(*number, 100);
+                assert_eq!(title, "Fix login bug");
+                assert!(*merged);
+                assert_eq!(author, "charlie");
+            }
+            other => panic!("Expected PullRequest, got {:?}", other),
+        }
+
+        // Third item: DraftIssue
+        match &items[2].content {
+            ProjectItemContent::DraftIssue {
+                title,
+                body,
+                assignees,
+            } => {
+                assert_eq!(title, "Research caching");
+                assert_eq!(body.as_deref(), Some("Investigate Redis vs Memcached"));
+                assert_eq!(assignees, &["alice"]);
+            }
+            other => panic!("Expected DraftIssue, got {:?}", other),
+        }
+        assert!(items[2].field_values.is_empty());
+    }
+
+    // -- Error classification tests --
+
+    #[test]
+    fn test_classify_permission_error() {
+        let errors = vec![GraphQLError {
+            message: "Resource not accessible by personal access token".to_string(),
+            error_type: Some("FORBIDDEN".to_string()),
+        }];
+
+        let err = classify_graphql_errors(&errors);
+        assert!(matches!(err, Error::MissingProjectScope { .. }));
+    }
+
+    #[test]
+    fn test_classify_not_found_error() {
+        let errors = vec![GraphQLError {
+            message: "Could not resolve to an Organization with the login of 'nonexistent'".to_string(),
+            error_type: Some("NOT_FOUND".to_string()),
+        }];
+
+        let err = classify_graphql_errors(&errors);
+        assert!(matches!(err, Error::NotFound(_)));
+    }
+
+    #[test]
+    fn test_classify_generic_error() {
+        let errors = vec![
+            GraphQLError {
+                message: "Something went wrong".to_string(),
+                error_type: None,
+            },
+            GraphQLError {
+                message: "Another error".to_string(),
+                error_type: None,
+            },
+        ];
+
+        let err = classify_graphql_errors(&errors);
+        match err {
+            Error::GraphQL(msg) => {
+                assert!(msg.contains("Something went wrong"));
+                assert!(msg.contains("Another error"));
+            }
+            other => panic!("Expected GraphQL error, got {:?}", other),
+        }
+    }
+
+    // -- Field value conversion tests --
+
+    #[test]
+    fn test_convert_iteration_field_value() {
+        let node = GqlFieldValueNode {
+            text: None,
+            number: None,
+            date: None,
+            name: None,
+            option_id: None,
+            title: Some("Sprint 1".to_string()),
+            start_date: Some("2026-01-06".to_string()),
+            duration: Some(14),
+            iteration_id: Some("it1".to_string()),
+            field: Some(GqlFieldRef {
+                name: Some("Sprint".to_string()),
+            }),
+        };
+
+        let fv = convert_field_value(node).unwrap();
+        assert_eq!(fv.field_name, "Sprint");
+        match fv.value {
+            FieldValue::Iteration {
+                title,
+                start_date,
+                duration,
+                iteration_id,
+            } => {
+                assert_eq!(title, "Sprint 1");
+                assert_eq!(start_date, "2026-01-06");
+                assert_eq!(duration, 14);
+                assert_eq!(iteration_id, "it1");
+            }
+            other => panic!("Expected Iteration, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_convert_date_field_value() {
+        let node = GqlFieldValueNode {
+            text: None,
+            number: None,
+            date: Some("2026-02-28".to_string()),
+            name: None,
+            option_id: None,
+            title: None,
+            start_date: None,
+            duration: None,
+            iteration_id: None,
+            field: Some(GqlFieldRef {
+                name: Some("Due Date".to_string()),
+            }),
+        };
+
+        let fv = convert_field_value(node).unwrap();
+        assert_eq!(fv.field_name, "Due Date");
+        match fv.value {
+            FieldValue::Date { value } => assert_eq!(value, "2026-02-28"),
+            other => panic!("Expected Date, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_convert_field_value_no_field_ref() {
+        let node = GqlFieldValueNode {
+            text: Some("hello".to_string()),
+            number: None,
+            date: None,
+            name: None,
+            option_id: None,
+            title: None,
+            start_date: None,
+            duration: None,
+            iteration_id: None,
+            field: None, // No field reference
+        };
+
+        assert!(convert_field_value(node).is_none());
+    }
+}

--- a/crates/greport-core/src/client/registry.rs
+++ b/crates/greport-core/src/client/registry.rs
@@ -473,10 +473,7 @@ mod tests {
         let client = OctocrabClient::new("ghp_test", None).unwrap();
         let registry = GitHubClientRegistry::with_default(client, None);
 
-        assert_eq!(
-            registry.web_url_for_owner("any-org"),
-            "https://github.com"
-        );
+        assert_eq!(registry.web_url_for_owner("any-org"), "https://github.com");
         assert_eq!(registry.default_web_url(), "https://github.com");
     }
 

--- a/crates/greport-core/src/error.rs
+++ b/crates/greport-core/src/error.rs
@@ -73,6 +73,27 @@ pub enum Error {
     #[error("Configuration error: {0}")]
     Config(String),
 
+    /// GraphQL API error
+    #[error("GraphQL error: {0}")]
+    GraphQL(String),
+
+    /// Missing required token scope for GitHub Projects
+    #[error(
+        "GitHub token for organization '{org}' lacks the 'read:project' scope. \
+         Update your token at https://github.com/settings/tokens"
+    )]
+    MissingProjectScope {
+        /// Organization name
+        org: String,
+    },
+
+    /// GitHub Projects V2 not available on this instance
+    #[error(
+        "GitHub Projects V2 is not available on this GitHub Enterprise instance. \
+         Requires GHES 3.6 or later."
+    )]
+    ProjectsNotAvailable,
+
     /// Custom error
     #[error("{0}")]
     Custom(String),

--- a/crates/greport-core/src/lib.rs
+++ b/crates/greport-core/src/lib.rs
@@ -13,6 +13,6 @@ pub mod metrics;
 pub mod models;
 pub mod reports;
 
-pub use client::{GitHubClient, GitHubClientRegistry, OctocrabClient, OrgEntry, RepoId};
+pub use client::{GitHubClient, GitHubClientRegistry, OctocrabClient, OrgEntry, ProjectClient, RepoId};
 pub use config::{Config, OrgConfig};
 pub use error::{Error, Result};

--- a/crates/greport-core/src/lib.rs
+++ b/crates/greport-core/src/lib.rs
@@ -13,6 +13,8 @@ pub mod metrics;
 pub mod models;
 pub mod reports;
 
-pub use client::{GitHubClient, GitHubClientRegistry, OctocrabClient, OrgEntry, ProjectClient, RepoId};
+pub use client::{
+    GitHubClient, GitHubClientRegistry, OctocrabClient, OrgEntry, ProjectClient, RepoId,
+};
 pub use config::{Config, OrgConfig};
 pub use error::{Error, Result};

--- a/crates/greport-core/src/models/mod.rs
+++ b/crates/greport-core/src/models/mod.rs
@@ -2,6 +2,7 @@
 
 mod calendar;
 mod issue;
+mod project;
 mod pull_request;
 mod release;
 mod release_plan;
@@ -10,6 +11,7 @@ mod user;
 
 pub use calendar::*;
 pub use issue::*;
+pub use project::*;
 pub use pull_request::*;
 pub use release::*;
 pub use release_plan::*;

--- a/crates/greport-core/src/models/project.rs
+++ b/crates/greport-core/src/models/project.rs
@@ -1,0 +1,174 @@
+//! GitHub Projects V2 data models
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A GitHub Project (V2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    /// GitHub GraphQL node ID (opaque string like "PVT_kwDO...")
+    pub node_id: String,
+    /// Project number within the organization
+    pub number: u64,
+    /// Project title
+    pub title: String,
+    /// Short description
+    pub description: Option<String>,
+    /// Web URL for the project
+    pub url: String,
+    /// Whether the project is closed
+    pub closed: bool,
+    /// Organization or user that owns the project
+    pub owner: String,
+    /// Creation timestamp
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp
+    pub updated_at: DateTime<Utc>,
+    /// Custom field definitions
+    pub fields: Vec<ProjectField>,
+    /// Total item count
+    pub total_items: u32,
+}
+
+/// A field definition on a project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectField {
+    /// GraphQL node ID
+    pub node_id: String,
+    /// Display name (e.g., "Status", "Priority", "Sprint")
+    pub name: String,
+    /// Field type with embedded configuration
+    pub field_type: ProjectFieldType,
+}
+
+/// Discriminated field type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProjectFieldType {
+    /// Plain text field
+    Text,
+    /// Numeric field
+    Number,
+    /// Date field
+    Date,
+    /// Single-select with predefined options
+    SingleSelect { options: Vec<SelectOption> },
+    /// Iteration/sprint field
+    Iteration { iterations: Vec<IterationValue> },
+    /// Built-in fields (Title, Assignees, Labels, etc.)
+    BuiltIn,
+}
+
+/// A single-select option.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectOption {
+    /// Option ID
+    pub id: String,
+    /// Display name
+    pub name: String,
+    /// Color code
+    pub color: Option<String>,
+    /// Description text
+    pub description: Option<String>,
+}
+
+/// An iteration/sprint value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IterationValue {
+    /// Iteration ID
+    pub id: String,
+    /// Display title (e.g., "Sprint 1")
+    pub title: String,
+    /// Start date (YYYY-MM-DD)
+    pub start_date: String,
+    /// Duration in days
+    pub duration: u32,
+}
+
+/// An item on a project board.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectItem {
+    /// GraphQL node ID
+    pub node_id: String,
+    /// The linked content (Issue, PR, or DraftIssue)
+    pub content: ProjectItemContent,
+    /// Field values for this item
+    pub field_values: Vec<ProjectFieldValue>,
+    /// Creation timestamp
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp
+    pub updated_at: DateTime<Utc>,
+}
+
+/// The content linked to a project item (union type).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProjectItemContent {
+    /// Linked issue
+    Issue {
+        number: u64,
+        title: String,
+        state: String,
+        url: String,
+        repository: String,
+        assignees: Vec<String>,
+        labels: Vec<LabelInfo>,
+    },
+    /// Linked pull request
+    PullRequest {
+        number: u64,
+        title: String,
+        state: String,
+        url: String,
+        repository: String,
+        merged: bool,
+        author: String,
+    },
+    /// Draft issue (not yet converted to a real issue)
+    DraftIssue {
+        title: String,
+        body: Option<String>,
+        assignees: Vec<String>,
+    },
+}
+
+/// Label summary for project items.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabelInfo {
+    /// Label name
+    pub name: String,
+    /// Color hex code
+    pub color: String,
+}
+
+/// A field value on a project item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectFieldValue {
+    /// The field name this value belongs to
+    pub field_name: String,
+    /// The typed value
+    pub value: FieldValue,
+}
+
+/// Typed field value (mirrors GraphQL union).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FieldValue {
+    /// Text value
+    Text { value: String },
+    /// Numeric value
+    Number { value: f64 },
+    /// Date value (YYYY-MM-DD)
+    Date { value: String },
+    /// Single-select value
+    SingleSelect { name: String, option_id: String },
+    /// Iteration value
+    Iteration {
+        title: String,
+        start_date: String,
+        duration: u32,
+        iteration_id: String,
+    },
+    /// No value set
+    Empty,
+}

--- a/crates/greport-db/migrations/003_add_projects.sql
+++ b/crates/greport-db/migrations/003_add_projects.sql
@@ -1,0 +1,54 @@
+-- Add GitHub Projects V2 tables
+
+-- Projects table
+CREATE TABLE IF NOT EXISTS projects (
+    node_id VARCHAR(255) PRIMARY KEY,
+    number BIGINT NOT NULL,
+    owner VARCHAR(255) NOT NULL,
+    title VARCHAR(512) NOT NULL,
+    description TEXT,
+    url VARCHAR(1024) NOT NULL,
+    closed BOOLEAN NOT NULL DEFAULT FALSE,
+    total_items INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(owner, number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_owner ON projects(owner);
+CREATE INDEX IF NOT EXISTS idx_projects_closed ON projects(closed);
+
+-- Project field definitions
+CREATE TABLE IF NOT EXISTS project_fields (
+    node_id VARCHAR(255) PRIMARY KEY,
+    project_id VARCHAR(255) NOT NULL REFERENCES projects(node_id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    field_type VARCHAR(50) NOT NULL,
+    config_json JSONB,
+    synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_fields_project ON project_fields(project_id);
+
+-- Project items (denormalized content)
+CREATE TABLE IF NOT EXISTS project_items (
+    node_id VARCHAR(255) PRIMARY KEY,
+    project_id VARCHAR(255) NOT NULL REFERENCES projects(node_id) ON DELETE CASCADE,
+    content_type VARCHAR(20) NOT NULL,
+    content_number BIGINT,
+    content_title TEXT NOT NULL,
+    content_state VARCHAR(20),
+    content_url VARCHAR(1024),
+    content_repository VARCHAR(512),
+    content_json JSONB,
+    field_values_json JSONB,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_items_project ON project_items(project_id);
+CREATE INDEX IF NOT EXISTS idx_project_items_content_type ON project_items(content_type);
+CREATE INDEX IF NOT EXISTS idx_project_items_repository ON project_items(content_repository);
+CREATE INDEX IF NOT EXISTS idx_project_items_state ON project_items(content_state);

--- a/crates/greport-db/src/models.rs
+++ b/crates/greport-db/src/models.rs
@@ -273,3 +273,94 @@ pub struct ApiKeyInput {
     pub rate_limit: i32,
     pub expires_at: Option<DateTime<Utc>>,
 }
+
+// =============================================================================
+// Project models (GitHub Projects V2)
+// =============================================================================
+
+/// Project record
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProjectRow {
+    pub node_id: String,
+    pub number: i64,
+    pub owner: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub closed: bool,
+    pub total_items: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub synced_at: DateTime<Utc>,
+}
+
+/// Project field definition record
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProjectFieldRow {
+    pub node_id: String,
+    pub project_id: String,
+    pub name: String,
+    pub field_type: String,
+    pub config_json: Option<serde_json::Value>,
+    pub synced_at: DateTime<Utc>,
+}
+
+/// Project item record
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ProjectItemRow {
+    pub node_id: String,
+    pub project_id: String,
+    pub content_type: String,
+    pub content_number: Option<i64>,
+    pub content_title: String,
+    pub content_state: Option<String>,
+    pub content_url: Option<String>,
+    pub content_repository: Option<String>,
+    pub content_json: Option<serde_json::Value>,
+    pub field_values_json: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub synced_at: DateTime<Utc>,
+}
+
+/// Input for creating/updating a project
+#[derive(Debug, Clone)]
+pub struct ProjectInput {
+    pub node_id: String,
+    pub number: i64,
+    pub owner: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub closed: bool,
+    pub total_items: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating/updating a project field
+#[derive(Debug, Clone)]
+pub struct ProjectFieldInput {
+    pub node_id: String,
+    pub project_id: String,
+    pub name: String,
+    pub field_type: String,
+    pub config_json: Option<serde_json::Value>,
+}
+
+/// Input for creating/updating a project item
+#[derive(Debug, Clone)]
+pub struct ProjectItemInput {
+    pub node_id: String,
+    pub project_id: String,
+    pub content_type: String,
+    pub content_number: Option<i64>,
+    pub content_title: String,
+    pub content_state: Option<String>,
+    pub content_url: Option<String>,
+    pub content_repository: Option<String>,
+    pub content_json: Option<serde_json::Value>,
+    pub field_values_json: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/greport-db/src/queries.rs
+++ b/crates/greport-db/src/queries.rs
@@ -1096,12 +1096,10 @@ pub async fn list_projects(
     include_closed: bool,
 ) -> sqlx::Result<Vec<ProjectRow>> {
     if include_closed {
-        sqlx::query_as::<_, ProjectRow>(
-            "SELECT * FROM projects WHERE owner = $1 ORDER BY number",
-        )
-        .bind(owner)
-        .fetch_all(pool)
-        .await
+        sqlx::query_as::<_, ProjectRow>("SELECT * FROM projects WHERE owner = $1 ORDER BY number")
+            .bind(owner)
+            .fetch_all(pool)
+            .await
     } else {
         sqlx::query_as::<_, ProjectRow>(
             "SELECT * FROM projects WHERE owner = $1 AND closed = FALSE ORDER BY number",
@@ -1118,13 +1116,11 @@ pub async fn get_project(
     owner: &str,
     number: i64,
 ) -> sqlx::Result<Option<ProjectRow>> {
-    sqlx::query_as::<_, ProjectRow>(
-        "SELECT * FROM projects WHERE owner = $1 AND number = $2",
-    )
-    .bind(owner)
-    .bind(number)
-    .fetch_optional(pool)
-    .await
+    sqlx::query_as::<_, ProjectRow>("SELECT * FROM projects WHERE owner = $1 AND number = $2")
+        .bind(owner)
+        .bind(number)
+        .fetch_optional(pool)
+        .await
 }
 
 /// Get project by node ID
@@ -1144,13 +1140,11 @@ pub async fn delete_stale_projects(
     owner: &str,
     current_node_ids: &[String],
 ) -> sqlx::Result<u64> {
-    let result = sqlx::query(
-        "DELETE FROM projects WHERE owner = $1 AND node_id != ALL($2)",
-    )
-    .bind(owner)
-    .bind(current_node_ids)
-    .execute(pool)
-    .await?;
+    let result = sqlx::query("DELETE FROM projects WHERE owner = $1 AND node_id != ALL($2)")
+        .bind(owner)
+        .bind(current_node_ids)
+        .execute(pool)
+        .await?;
     Ok(result.rows_affected())
 }
 

--- a/crates/greport-db/src/queries.rs
+++ b/crates/greport-db/src/queries.rs
@@ -1051,6 +1051,265 @@ pub async fn list_repositories_by_org(
     .await
 }
 
+// =============================================================================
+// Project queries (GitHub Projects V2)
+// =============================================================================
+
+/// Upsert project
+pub async fn upsert_project(pool: &DbPool, input: &ProjectInput) -> sqlx::Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO projects (node_id, number, owner, title, description, url, closed,
+                              total_items, created_at, updated_at, synced_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+        ON CONFLICT (node_id) DO UPDATE SET
+            number = EXCLUDED.number,
+            title = EXCLUDED.title,
+            description = EXCLUDED.description,
+            url = EXCLUDED.url,
+            closed = EXCLUDED.closed,
+            total_items = EXCLUDED.total_items,
+            updated_at = EXCLUDED.updated_at,
+            synced_at = NOW()
+        "#,
+    )
+    .bind(&input.node_id)
+    .bind(input.number)
+    .bind(&input.owner)
+    .bind(&input.title)
+    .bind(&input.description)
+    .bind(&input.url)
+    .bind(input.closed)
+    .bind(input.total_items)
+    .bind(input.created_at)
+    .bind(input.updated_at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// List projects for an organization
+pub async fn list_projects(
+    pool: &DbPool,
+    owner: &str,
+    include_closed: bool,
+) -> sqlx::Result<Vec<ProjectRow>> {
+    if include_closed {
+        sqlx::query_as::<_, ProjectRow>(
+            "SELECT * FROM projects WHERE owner = $1 ORDER BY number",
+        )
+        .bind(owner)
+        .fetch_all(pool)
+        .await
+    } else {
+        sqlx::query_as::<_, ProjectRow>(
+            "SELECT * FROM projects WHERE owner = $1 AND closed = FALSE ORDER BY number",
+        )
+        .bind(owner)
+        .fetch_all(pool)
+        .await
+    }
+}
+
+/// Get project by owner and number
+pub async fn get_project(
+    pool: &DbPool,
+    owner: &str,
+    number: i64,
+) -> sqlx::Result<Option<ProjectRow>> {
+    sqlx::query_as::<_, ProjectRow>(
+        "SELECT * FROM projects WHERE owner = $1 AND number = $2",
+    )
+    .bind(owner)
+    .bind(number)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Get project by node ID
+pub async fn get_project_by_node_id(
+    pool: &DbPool,
+    node_id: &str,
+) -> sqlx::Result<Option<ProjectRow>> {
+    sqlx::query_as::<_, ProjectRow>("SELECT * FROM projects WHERE node_id = $1")
+        .bind(node_id)
+        .fetch_optional(pool)
+        .await
+}
+
+/// Delete projects not in the current list (stale cleanup)
+pub async fn delete_stale_projects(
+    pool: &DbPool,
+    owner: &str,
+    current_node_ids: &[String],
+) -> sqlx::Result<u64> {
+    let result = sqlx::query(
+        "DELETE FROM projects WHERE owner = $1 AND node_id != ALL($2)",
+    )
+    .bind(owner)
+    .bind(current_node_ids)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Replace all field definitions for a project (delete + insert)
+pub async fn replace_project_fields(
+    pool: &DbPool,
+    project_id: &str,
+    fields: &[ProjectFieldInput],
+) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM project_fields WHERE project_id = $1")
+        .bind(project_id)
+        .execute(pool)
+        .await?;
+
+    for field in fields {
+        sqlx::query(
+            r#"
+            INSERT INTO project_fields (node_id, project_id, name, field_type, config_json, synced_at)
+            VALUES ($1, $2, $3, $4, $5, NOW())
+            "#,
+        )
+        .bind(&field.node_id)
+        .bind(&field.project_id)
+        .bind(&field.name)
+        .bind(&field.field_type)
+        .bind(&field.config_json)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// List field definitions for a project
+pub async fn list_project_fields(
+    pool: &DbPool,
+    project_id: &str,
+) -> sqlx::Result<Vec<ProjectFieldRow>> {
+    sqlx::query_as::<_, ProjectFieldRow>(
+        "SELECT * FROM project_fields WHERE project_id = $1 ORDER BY name",
+    )
+    .bind(project_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// Replace all items for a project (delete + insert)
+pub async fn replace_project_items(
+    pool: &DbPool,
+    project_id: &str,
+    items: &[ProjectItemInput],
+) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM project_items WHERE project_id = $1")
+        .bind(project_id)
+        .execute(pool)
+        .await?;
+
+    for item in items {
+        sqlx::query(
+            r#"
+            INSERT INTO project_items (node_id, project_id, content_type, content_number,
+                                       content_title, content_state, content_url,
+                                       content_repository, content_json, field_values_json,
+                                       created_at, updated_at, synced_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW())
+            "#,
+        )
+        .bind(&item.node_id)
+        .bind(&item.project_id)
+        .bind(&item.content_type)
+        .bind(item.content_number)
+        .bind(&item.content_title)
+        .bind(&item.content_state)
+        .bind(&item.content_url)
+        .bind(&item.content_repository)
+        .bind(&item.content_json)
+        .bind(&item.field_values_json)
+        .bind(item.created_at)
+        .bind(item.updated_at)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// List items for a project with optional filters
+pub async fn list_project_items(
+    pool: &DbPool,
+    project_id: &str,
+    content_type: Option<&str>,
+    content_state: Option<&str>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+) -> sqlx::Result<Vec<ProjectItemRow>> {
+    let mut query = String::from("SELECT * FROM project_items WHERE project_id = $1");
+    let mut param_count = 1;
+
+    if content_type.is_some() {
+        param_count += 1;
+        query.push_str(&format!(" AND content_type = ${}", param_count));
+    }
+
+    if content_state.is_some() {
+        param_count += 1;
+        query.push_str(&format!(" AND content_state = ${}", param_count));
+    }
+
+    query.push_str(" ORDER BY updated_at DESC");
+
+    if let Some(l) = limit {
+        query.push_str(&format!(" LIMIT {}", l));
+    }
+    if let Some(o) = offset {
+        query.push_str(&format!(" OFFSET {}", o));
+    }
+
+    let mut q = sqlx::query_as::<_, ProjectItemRow>(&query).bind(project_id);
+
+    if let Some(ct) = content_type {
+        q = q.bind(ct);
+    }
+    if let Some(cs) = content_state {
+        q = q.bind(cs);
+    }
+
+    q.fetch_all(pool).await
+}
+
+/// Count project items by status field value
+pub async fn count_project_items_by_status(
+    pool: &DbPool,
+    project_id: &str,
+    status_field_name: &str,
+) -> sqlx::Result<Vec<(String, i64)>> {
+    // Extract status from field_values_json array where field_name matches
+    sqlx::query_as::<_, (String, i64)>(
+        r#"
+        SELECT
+            COALESCE(fv->>'name', 'No Status') as status,
+            COUNT(*) as count
+        FROM project_items pi,
+             LATERAL (
+                SELECT value as fv
+                FROM jsonb_array_elements(pi.field_values_json) as value
+                WHERE value->>'field_name' = $2
+                LIMIT 1
+             ) sub
+        WHERE pi.project_id = $1
+        GROUP BY status
+        ORDER BY count DESC
+        "#,
+    )
+    .bind(project_id)
+    .bind(status_field_name)
+    .fetch_all(pool)
+    .await
+}
+
 /// Check if data needs refresh based on sync time
 pub async fn needs_refresh(
     pool: &DbPool,

--- a/dashboard/src/app/projects/[org]/[number]/page.tsx
+++ b/dashboard/src/app/projects/[org]/[number]/page.tsx
@@ -1,0 +1,615 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useProjectDetail, useProjectItems, useProjectMetrics } from "@/hooks/use-api";
+import { DataTable, type Column } from "@/components/shared/data-table";
+import { Pagination } from "@/components/shared/pagination";
+import { MetricCard } from "@/components/shared/metric-card";
+import { PageLoading } from "@/components/shared/loading";
+import { ErrorDisplay } from "@/components/shared/error-display";
+import { PieChartComponent } from "@/components/charts/pie-chart-component";
+import { BarChartComponent } from "@/components/charts/bar-chart-component";
+import type { ProjectItemResponse, ProjectFieldSummary } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Field value helpers
+// ---------------------------------------------------------------------------
+
+interface FieldValue {
+  field_name: string;
+  type: string;
+  value?: string;
+  name?: string;
+  option_id?: string;
+  title?: string;
+  start_date?: string;
+  duration?: number;
+  iteration_id?: string;
+}
+
+interface SelectOption {
+  id: string;
+  name: string;
+  color?: string;
+  description?: string;
+}
+
+function getFieldValue(item: ProjectItemResponse, fieldName: string): FieldValue | undefined {
+  if (!Array.isArray(item.field_values)) return undefined;
+  return (item.field_values as FieldValue[]).find((fv) => fv.field_name === fieldName);
+}
+
+function getFieldDisplayValue(fv: FieldValue | undefined): string {
+  if (!fv) return "";
+  if (fv.type === "single_select") return fv.name || "";
+  if (fv.type === "iteration") return fv.title || "";
+  if (fv.type === "number") return fv.value ?? "";
+  if (fv.type === "date") return fv.value ?? "";
+  return fv.value ?? "";
+}
+
+function getStatusForItem(item: ProjectItemResponse): string {
+  const fv = getFieldValue(item, "Status");
+  if (fv?.type === "single_select" && fv.name) return fv.name;
+  return "No Status";
+}
+
+const STATUS_COLORS: Record<string, { bg: string; border: string; dot: string }> = {
+  GREEN: { bg: "bg-green-50 dark:bg-green-950", border: "border-green-300 dark:border-green-700", dot: "bg-green-500" },
+  YELLOW: { bg: "bg-yellow-50 dark:bg-yellow-950", border: "border-yellow-300 dark:border-yellow-700", dot: "bg-yellow-500" },
+  PURPLE: { bg: "bg-purple-50 dark:bg-purple-950", border: "border-purple-300 dark:border-purple-700", dot: "bg-purple-500" },
+  RED: { bg: "bg-red-50 dark:bg-red-950", border: "border-red-300 dark:border-red-700", dot: "bg-red-500" },
+  ORANGE: { bg: "bg-orange-50 dark:bg-orange-950", border: "border-orange-300 dark:border-orange-700", dot: "bg-orange-500" },
+  BLUE: { bg: "bg-blue-50 dark:bg-blue-950", border: "border-blue-300 dark:border-blue-700", dot: "bg-blue-500" },
+  PINK: { bg: "bg-pink-50 dark:bg-pink-950", border: "border-pink-300 dark:border-pink-700", dot: "bg-pink-500" },
+  GRAY: { bg: "bg-gray-50 dark:bg-gray-900", border: "border-gray-300 dark:border-gray-700", dot: "bg-gray-500" },
+};
+
+const DEFAULT_STATUS_COLOR = STATUS_COLORS.GRAY;
+
+function getStatusColumns(fields: ProjectFieldSummary[]): { name: string; color: string }[] {
+  const statusField = fields.find((f) => f.name === "Status" && f.field_type === "single_select");
+  if (!statusField || !Array.isArray(statusField.config_json)) return [];
+  return (statusField.config_json as SelectOption[]).map((opt) => ({
+    name: opt.name,
+    color: opt.color || "GRAY",
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
+
+export default function ProjectDetailPage() {
+  const params = useParams();
+  const org = params.org as string;
+  const number = params.number ? Number(params.number) : null;
+
+  const [viewMode, setViewMode] = useState<"board" | "table">("board");
+  const [contentType, setContentType] = useState("all");
+  const [stateFilter, setStateFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const perPage = 100;
+
+  const itemParams: { content_type?: string; state?: string; page?: number; per_page?: number } = {
+    page,
+    per_page: perPage,
+  };
+  if (contentType !== "all") itemParams.content_type = contentType;
+  if (stateFilter !== "all") itemParams.state = stateFilter;
+
+  const { data: detailData, error: detailError, isLoading: detailLoading } = useProjectDetail(org, number);
+  const { data: itemsData, error: itemsError, isLoading: itemsLoading } = useProjectItems(org, number, itemParams);
+  const { data: metricsData } = useProjectMetrics(org, number);
+
+  if (detailLoading) return <PageLoading />;
+  if (detailError) return <ErrorDisplay message={detailError.message} />;
+
+  const project = detailData?.data;
+  if (!project) return <ErrorDisplay message="Project not found" />;
+
+  const items = itemsData?.data || [];
+  const meta = itemsData?.meta;
+  const metrics = metricsData?.data;
+
+  const statusColumns = getStatusColumns(project.fields);
+  const hasStatusField = statusColumns.length > 0;
+
+  // Extra fields worth showing (non-built-in, non-Status)
+  const extraFields = project.fields.filter(
+    (f) => f.field_type !== "built_in" && f.name !== "Status",
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/projects"
+        className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        <svg className="mr-1 h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+        </svg>
+        All Projects
+      </Link>
+
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-3">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+              {project.title}
+            </h2>
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                project.closed
+                  ? "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300"
+                  : "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
+              }`}
+            >
+              {project.closed ? "Closed" : "Open"}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {project.owner}
+          </p>
+          {project.description && (
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{project.description}</p>
+          )}
+        </div>
+        <a
+          href={project.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          Open on GitHub
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+          </svg>
+        </a>
+      </div>
+
+      {/* Metric cards */}
+      {metrics && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <MetricCard title="Total Items" value={metrics.total_items} />
+          {metrics.by_status.slice(0, 3).map((s) => (
+            <MetricCard key={s.status} title={s.status || "No Status"} value={s.count} />
+          ))}
+        </div>
+      )}
+
+      {/* View toggle + filters */}
+      <div className="flex flex-wrap items-center gap-4">
+        {hasStatusField && (
+          <div className="inline-flex rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+            <button
+              onClick={() => setViewMode("board")}
+              className={`inline-flex items-center gap-1.5 rounded-l-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                viewMode === "board"
+                  ? "bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                  : "text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800"
+              }`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z" />
+              </svg>
+              Board
+            </button>
+            <button
+              onClick={() => setViewMode("table")}
+              className={`inline-flex items-center gap-1.5 rounded-r-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                viewMode === "table"
+                  ? "bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                  : "text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800"
+              }`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125" />
+              </svg>
+              Table
+            </button>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <select
+            value={contentType}
+            onChange={(e) => { setContentType(e.target.value); setPage(1); }}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          >
+            <option value="all">All Types</option>
+            <option value="Issue">Issue</option>
+            <option value="PullRequest">Pull Request</option>
+            <option value="DraftIssue">Draft Issue</option>
+          </select>
+          <select
+            value={stateFilter}
+            onChange={(e) => { setStateFilter(e.target.value); setPage(1); }}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          >
+            <option value="all">All States</option>
+            <option value="open">Open</option>
+            <option value="closed">Closed</option>
+            <option value="merged">Merged</option>
+          </select>
+          {(contentType !== "all" || stateFilter !== "all") && (
+            <button
+              onClick={() => { setContentType("all"); setStateFilter("all"); setPage(1); }}
+              className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Board or Table view */}
+      {itemsLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+        </div>
+      ) : itemsError ? (
+        <ErrorDisplay message={itemsError.message} />
+      ) : viewMode === "board" && hasStatusField ? (
+        <BoardView items={items} statusColumns={statusColumns} extraFields={extraFields} />
+      ) : (
+        <TableView items={items} meta={meta} extraFields={extraFields} onPageChange={setPage} />
+      )}
+
+      {/* Pagination for board view */}
+      {viewMode === "board" && meta && meta.total_pages > 1 && (
+        <Pagination meta={meta} onPageChange={setPage} />
+      )}
+
+      {/* Charts */}
+      {metrics && (metrics.by_status.length > 0 || metrics.by_content_type.length > 0) && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          {metrics.by_status.length > 0 && (
+            <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+              <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+                Status Distribution
+              </h3>
+              <PieChartComponent
+                data={metrics.by_status.map((s) => ({ name: s.status || "No Status", value: s.count }))}
+              />
+            </div>
+          )}
+          {metrics.by_content_type.length > 0 && (
+            <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+              <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+                Content Type Distribution
+              </h3>
+              <BarChartComponent
+                data={metrics.by_content_type.map((c) => ({ name: c.content_type, value: c.count }))}
+                layout="horizontal"
+                color="#8b5cf6"
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Board View (Kanban)
+// ---------------------------------------------------------------------------
+
+function BoardView({
+  items,
+  statusColumns,
+  extraFields,
+}: {
+  items: ProjectItemResponse[];
+  statusColumns: { name: string; color: string }[];
+  extraFields: ProjectFieldSummary[];
+}) {
+  const grouped = useMemo(() => {
+    const groups: Record<string, ProjectItemResponse[]> = {};
+    // Initialize columns in order
+    for (const col of statusColumns) {
+      groups[col.name] = [];
+    }
+    groups["No Status"] = [];
+
+    for (const item of items) {
+      const status = getStatusForItem(item);
+      if (groups[status]) {
+        groups[status].push(item);
+      } else {
+        groups["No Status"].push(item);
+      }
+    }
+    return groups;
+  }, [items, statusColumns]);
+
+  // Only show "No Status" column if it has items
+  const columnsToShow = [
+    ...statusColumns,
+    ...(grouped["No Status"].length > 0 ? [{ name: "No Status", color: "GRAY" }] : []),
+  ];
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-12 text-center dark:border-gray-800 dark:bg-gray-900">
+        <p className="text-sm text-gray-500 dark:text-gray-400">No items in this project</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-4 overflow-x-auto pb-4">
+      {columnsToShow.map((col) => {
+        const colItems = grouped[col.name] || [];
+        const colors = STATUS_COLORS[col.color] || DEFAULT_STATUS_COLOR;
+        return (
+          <div key={col.name} className="flex w-72 flex-shrink-0 flex-col">
+            {/* Column header */}
+            <div className={`flex items-center gap-2 rounded-t-lg border ${colors.border} ${colors.bg} px-3 py-2`}>
+              <span className={`h-2.5 w-2.5 rounded-full ${colors.dot}`} />
+              <span className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                {col.name}
+              </span>
+              <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+                {colItems.length}
+              </span>
+            </div>
+            {/* Cards */}
+            <div className="flex flex-1 flex-col gap-2 rounded-b-lg border border-t-0 border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900/50">
+              {colItems.length === 0 ? (
+                <p className="py-4 text-center text-xs text-gray-400 dark:text-gray-600">
+                  No items
+                </p>
+              ) : (
+                colItems.map((item) => (
+                  <ItemCard key={item.node_id} item={item} extraFields={extraFields} />
+                ))
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Item Card (for board view)
+// ---------------------------------------------------------------------------
+
+function ItemCard({
+  item,
+  extraFields,
+}: {
+  item: ProjectItemResponse;
+  extraFields: ProjectFieldSummary[];
+}) {
+  const typeColors: Record<string, string> = {
+    issue: "text-blue-600 dark:text-blue-400",
+    pullrequest: "text-purple-600 dark:text-purple-400",
+    draftissue: "text-gray-500 dark:text-gray-400",
+  };
+
+  const typeIcons: Record<string, string> = {
+    issue: "M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z",
+    pullrequest: "M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5",
+    draftissue: "M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z",
+  };
+
+  const ct = item.content_type.toLowerCase();
+  const stateColor = item.content_state === "OPEN" || item.content_state === "open"
+    ? "text-green-600 dark:text-green-400"
+    : item.content_state === "MERGED" || item.content_state === "merged"
+      ? "text-purple-600 dark:text-purple-400"
+      : "text-red-600 dark:text-red-400";
+
+  // Collect displayable extra field values
+  const fieldBadges: { name: string; value: string }[] = [];
+  for (const f of extraFields) {
+    const fv = getFieldValue(item, f.name);
+    const display = getFieldDisplayValue(fv);
+    if (display) fieldBadges.push({ name: f.name, value: display });
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800">
+      {/* Title row */}
+      <div className="flex items-start gap-2">
+        <svg
+          className={`mt-0.5 h-4 w-4 flex-shrink-0 ${typeColors[ct] || "text-gray-500"}`}
+          fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d={typeIcons[ct] || typeIcons.issue} />
+        </svg>
+        <div className="min-w-0 flex-1">
+          {item.content_url ? (
+            <a
+              href={item.content_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-gray-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
+            >
+              {item.content_title}
+            </a>
+          ) : (
+            <span className="text-sm font-medium text-gray-900 dark:text-white">
+              {item.content_title}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Meta row */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+        {item.content_number && (
+          <span className="font-mono">#{item.content_number}</span>
+        )}
+        {item.content_state && (
+          <span className={`font-medium ${stateColor}`}>
+            {item.content_state.charAt(0) + item.content_state.slice(1).toLowerCase()}
+          </span>
+        )}
+        {item.content_repository && (
+          <span>{item.content_repository.split("/").pop()}</span>
+        )}
+      </div>
+
+      {/* Field value badges */}
+      {fieldBadges.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {fieldBadges.map((fb) => (
+            <span
+              key={fb.name}
+              className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+              title={fb.name}
+            >
+              {fb.value}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table View
+// ---------------------------------------------------------------------------
+
+function TableView({
+  items,
+  meta,
+  extraFields,
+  onPageChange,
+}: {
+  items: ProjectItemResponse[];
+  meta?: { page: number; per_page: number; total: number; total_pages: number };
+  extraFields: ProjectFieldSummary[];
+  onPageChange: (page: number) => void;
+}) {
+  const columns: Column<ProjectItemResponse>[] = [
+    {
+      key: "content_number",
+      header: "#",
+      sortable: true,
+      className: "w-16",
+      render: (item) => (
+        <span className="font-mono text-xs text-gray-500">
+          {item.content_number ? `#${item.content_number}` : "-"}
+        </span>
+      ),
+    },
+    {
+      key: "content_title",
+      header: "Title",
+      render: (item) => (
+        <div className="max-w-md">
+          {item.content_url ? (
+            <a
+              href={item.content_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="truncate font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {item.content_title}
+            </a>
+          ) : (
+            <p className="truncate font-medium text-gray-900 dark:text-white">
+              {item.content_title}
+            </p>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (item) => {
+        const status = getStatusForItem(item);
+        if (status === "No Status") return <span className="text-sm text-gray-400">-</span>;
+        return (
+          <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+            {status}
+          </span>
+        );
+      },
+    },
+    {
+      key: "content_type",
+      header: "Type",
+      render: (item) => {
+        const typeColors: Record<string, string> = {
+          issue: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+          pullrequest: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+          draftissue: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+        };
+        const ct = item.content_type.toLowerCase();
+        return (
+          <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${typeColors[ct] || "bg-gray-100 text-gray-700"}`}>
+            {item.content_type}
+          </span>
+        );
+      },
+    },
+    {
+      key: "content_state",
+      header: "State",
+      render: (item) => {
+        if (!item.content_state) return <span className="text-sm text-gray-400">-</span>;
+        const s = item.content_state.toLowerCase();
+        const stateColors: Record<string, string> = {
+          open: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+          closed: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+          merged: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+        };
+        return (
+          <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${stateColors[s] || "bg-gray-100 text-gray-700"}`}>
+            {item.content_state}
+          </span>
+        );
+      },
+    },
+    {
+      key: "content_repository",
+      header: "Repository",
+      render: (item) => (
+        <span className="text-sm text-gray-600 dark:text-gray-300">
+          {item.content_repository ? item.content_repository.split("/").pop() || item.content_repository : "-"}
+        </span>
+      ),
+    },
+    // Dynamic columns for extra fields
+    ...extraFields.map((f) => ({
+      key: `field_${f.name}`,
+      header: f.name,
+      render: (item: ProjectItemResponse) => {
+        const fv = getFieldValue(item, f.name);
+        const display = getFieldDisplayValue(fv);
+        if (!display) return <span className="text-sm text-gray-400">-</span>;
+        return (
+          <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+            {display}
+          </span>
+        );
+      },
+    })),
+  ];
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 shadow-sm dark:border-gray-800">
+      <DataTable
+        columns={columns}
+        data={items}
+        keyExtractor={(item) => item.node_id}
+        emptyMessage="No items found matching the filters"
+      />
+      {meta && <Pagination meta={meta} onPageChange={onPageChange} />}
+    </div>
+  );
+}

--- a/dashboard/src/app/projects/page.tsx
+++ b/dashboard/src/app/projects/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useRepo } from "@/hooks/use-repo";
+import { useProjects, useAggregateProjects } from "@/hooks/use-api";
+import { DataTable, type Column } from "@/components/shared/data-table";
+import { FilterPanel } from "@/components/shared/filter-panel";
+import { MetricCard } from "@/components/shared/metric-card";
+import { PageLoading } from "@/components/shared/loading";
+import { ErrorDisplay, NoRepoSelected } from "@/components/shared/error-display";
+import { formatRelativeTime, formatDate } from "@/lib/utils";
+import type { ProjectSummary } from "@/types/api";
+
+export default function ProjectsPage() {
+  const { owner, mode } = useRepo();
+
+  if (mode === "aggregate") {
+    return <AggregateProjectsView />;
+  }
+
+  if (!owner) return <NoRepoSelected />;
+
+  return <ProjectsContent org={owner} />;
+}
+
+function AggregateProjectsView() {
+  const router = useRouter();
+  const [includeClosed, setIncludeClosed] = useState(false);
+
+  const { data, error, isLoading } = useAggregateProjects(
+    includeClosed ? { include_closed: true } : undefined,
+  );
+
+  if (isLoading) return <PageLoading />;
+  if (error) return <ErrorDisplay message={error.message} />;
+
+  const projects = data?.data || [];
+  const openProjects = projects.filter((p) => !p.closed);
+  const totalItems = projects.reduce((sum, p) => sum + p.total_items, 0);
+
+  return (
+    <ProjectsView
+      title="Projects"
+      subtitle="All Organizations"
+      projects={projects}
+      openCount={openProjects.length}
+      totalItems={totalItems}
+      includeClosed={includeClosed}
+      onIncludeClosedChange={setIncludeClosed}
+      onRowClick={(project) => router.push(`/projects/${project.owner}/${project.number}`)}
+    />
+  );
+}
+
+function ProjectsContent({ org }: { org: string }) {
+  const router = useRouter();
+  const [includeClosed, setIncludeClosed] = useState(false);
+
+  const { data, error, isLoading } = useProjects(
+    org,
+    includeClosed ? { include_closed: true } : undefined,
+  );
+
+  if (isLoading) return <PageLoading />;
+  if (error) return <ErrorDisplay message={error.message} />;
+
+  const projects = data?.data || [];
+  const openProjects = projects.filter((p) => !p.closed);
+  const totalItems = projects.reduce((sum, p) => sum + p.total_items, 0);
+
+  return (
+    <ProjectsView
+      title="Projects"
+      subtitle={org}
+      projects={projects}
+      openCount={openProjects.length}
+      totalItems={totalItems}
+      includeClosed={includeClosed}
+      onIncludeClosedChange={setIncludeClosed}
+      onRowClick={(project) => router.push(`/projects/${project.owner}/${project.number}`)}
+    />
+  );
+}
+
+interface ProjectsViewProps {
+  title: string;
+  subtitle: string;
+  projects: ProjectSummary[];
+  openCount: number;
+  totalItems: number;
+  includeClosed: boolean;
+  onIncludeClosedChange: (value: boolean) => void;
+  onRowClick: (project: ProjectSummary) => void;
+}
+
+function ProjectsView({
+  title,
+  subtitle,
+  projects,
+  openCount,
+  totalItems,
+  includeClosed,
+  onIncludeClosedChange,
+  onRowClick,
+}: ProjectsViewProps) {
+  const columns: Column<ProjectSummary>[] = [
+    {
+      key: "number",
+      header: "#",
+      sortable: true,
+      className: "w-16",
+      render: (item) => (
+        <span className="font-mono text-xs text-gray-500">#{item.number}</span>
+      ),
+    },
+    {
+      key: "title",
+      header: "Title",
+      render: (item) => (
+        <div className="max-w-md">
+          <p className="truncate font-medium text-gray-900 dark:text-white">
+            {item.title}
+          </p>
+          {item.description && (
+            <p className="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">
+              {item.description}
+            </p>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: "owner",
+      header: "Owner",
+      render: (item) => (
+        <span className="text-sm text-gray-600 dark:text-gray-300">
+          {item.owner}
+        </span>
+      ),
+    },
+    {
+      key: "total_items",
+      header: "Items",
+      sortable: true,
+      className: "w-20",
+      render: (item) => (
+        <span className="text-sm text-gray-600 dark:text-gray-300">
+          {item.total_items}
+        </span>
+      ),
+    },
+    {
+      key: "closed",
+      header: "Status",
+      render: (item) => (
+        <span
+          className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
+            item.closed
+              ? "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300"
+              : "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
+          }`}
+        >
+          {item.closed ? "Closed" : "Open"}
+        </span>
+      ),
+    },
+    {
+      key: "synced_at",
+      header: "Last Synced",
+      sortable: true,
+      render: (item) => (
+        <span className="text-sm text-gray-500" title={formatDate(item.synced_at)}>
+          {formatRelativeTime(item.synced_at)}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{title}</h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{subtitle}</p>
+      </div>
+
+      <FilterPanel
+        filters={[
+          {
+            key: "status",
+            label: "Status",
+            value: includeClosed ? "all" : "open",
+            onChange: (v) => onIncludeClosedChange(v === "all"),
+            options: [
+              { label: "Open Only", value: "open" },
+              { label: "Include Closed", value: "all" },
+            ],
+          },
+        ]}
+        onClear={() => onIncludeClosedChange(false)}
+      />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <MetricCard title="Total Projects" value={projects.length} />
+        <MetricCard title="Open Projects" value={openCount} />
+        <MetricCard title="Total Items" value={totalItems} />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-gray-200 shadow-sm dark:border-gray-800">
+        <DataTable
+          columns={columns}
+          data={projects}
+          keyExtractor={(p) => `${p.owner}-${p.number}`}
+          onRowClick={onRowClick}
+          emptyMessage="No projects found"
+        />
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: "Velocity", href: "/velocity", icon: TrendingUpIcon },
   { name: "Contributors", href: "/contributors", icon: UsersIcon },
   { name: "SLA", href: "/sla", icon: ShieldIcon },
+  { name: "Projects", href: "/projects", icon: ClipboardIcon },
   { name: "Settings", href: "/settings", icon: GearIcon },
 ];
 
@@ -127,6 +128,14 @@ function CalendarIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+    </svg>
+  );
+}
+
+function ClipboardIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z" />
     </svg>
   );
 }

--- a/dashboard/src/hooks/use-api.ts
+++ b/dashboard/src/hooks/use-api.ts
@@ -24,6 +24,11 @@ import {
   aggregateCalendarUrl,
   releasePlanUrl,
   aggregateReleasePlanUrl,
+  projectsUrl,
+  projectDetailUrl,
+  projectItemsUrl,
+  projectMetricsUrl,
+  aggregateProjectsUrl,
 } from "@/lib/api";
 import type {
   ApiResponse,
@@ -47,6 +52,10 @@ import type {
   AggregateVelocityMetrics,
   CalendarData,
   ReleasePlan,
+  ProjectSummary,
+  ProjectDetail,
+  ProjectItemResponse,
+  ProjectMetrics,
 } from "@/types/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9423";
@@ -262,5 +271,52 @@ export function useAggregateReleasePlan(
 ) {
   return useApi<ApiResponse<ReleasePlan>>(
     aggregateReleasePlanUrl(params),
+  );
+}
+
+// Projects hooks
+
+export function useProjects(
+  org: string,
+  params?: { include_closed?: boolean },
+) {
+  return useApi<ApiResponse<ProjectSummary[]>>(
+    org ? projectsUrl(org, params) : null,
+  );
+}
+
+export function useProjectDetail(
+  org: string,
+  number: number | null,
+) {
+  return useApi<ApiResponse<ProjectDetail>>(
+    org && number !== null ? projectDetailUrl(org, number) : null,
+  );
+}
+
+export function useProjectItems(
+  org: string,
+  number: number | null,
+  params?: { content_type?: string; state?: string; page?: number; per_page?: number },
+) {
+  return useApi<PaginatedResponse<ProjectItemResponse>>(
+    org && number !== null ? projectItemsUrl(org, number, params) : null,
+  );
+}
+
+export function useProjectMetrics(
+  org: string,
+  number: number | null,
+) {
+  return useApi<ApiResponse<ProjectMetrics>>(
+    org && number !== null ? projectMetricsUrl(org, number) : null,
+  );
+}
+
+export function useAggregateProjects(
+  params?: { include_closed?: boolean },
+) {
+  return useApi<ApiResponse<ProjectSummary[]>>(
+    aggregateProjectsUrl(params),
   );
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -16,6 +16,13 @@ import type {
   ErrorResponse,
   RepoSummary,
   BatchSyncResult,
+  ProjectSummary,
+  ProjectDetail,
+  ProjectItemResponse,
+  ProjectMetrics,
+  ProjectFieldSummary,
+  StatusCount,
+  ContentTypeCount,
 } from "@/types/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9423";
@@ -296,6 +303,44 @@ export function aggregateReleasePlanUrl(
   return `/api/v1/aggregate/release-plan${buildQuery(params || {})}`;
 }
 
+// Projects
+export function projectsUrl(
+  org: string,
+  params?: { include_closed?: boolean },
+): string {
+  const query: Record<string, string | number | undefined> = {};
+  if (params?.include_closed !== undefined) {
+    query.include_closed = params.include_closed ? "true" : "false";
+  }
+  return `/api/v1/orgs/${org}/projects${buildQuery(query)}`;
+}
+
+export function projectDetailUrl(org: string, number: number): string {
+  return `/api/v1/orgs/${org}/projects/${number}`;
+}
+
+export function projectItemsUrl(
+  org: string,
+  number: number,
+  params?: { content_type?: string; state?: string; page?: number; per_page?: number },
+): string {
+  return `/api/v1/orgs/${org}/projects/${number}/items${buildQuery(params || {})}`;
+}
+
+export function projectMetricsUrl(org: string, number: number): string {
+  return `/api/v1/orgs/${org}/projects/${number}/metrics`;
+}
+
+export function aggregateProjectsUrl(
+  params?: { include_closed?: boolean },
+): string {
+  const query: Record<string, string | number | undefined> = {};
+  if (params?.include_closed !== undefined) {
+    query.include_closed = params.include_closed ? "true" : "false";
+  }
+  return `/api/v1/aggregate/projects${buildQuery(query)}`;
+}
+
 // Re-export types for convenience
 export type {
   ApiResponse,
@@ -312,4 +357,11 @@ export type {
   SlaReportResponse,
   ContributorStats,
   SyncResult,
+  ProjectSummary,
+  ProjectDetail,
+  ProjectItemResponse,
+  ProjectMetrics,
+  ProjectFieldSummary,
+  StatusCount,
+  ContentTypeCount,
 };

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -447,6 +447,58 @@ export interface ReleasePlan {
   timeline: TimelineEntry[];
 }
 
+// GitHub Projects V2 types
+
+export interface ProjectSummary {
+  number: number;
+  owner: string;
+  title: string;
+  description?: string;
+  url: string;
+  closed: boolean;
+  total_items: number;
+  synced_at: string;
+}
+
+export interface ProjectFieldSummary {
+  name: string;
+  field_type: string;
+  config_json?: unknown;
+}
+
+export interface ProjectDetail extends ProjectSummary {
+  fields: ProjectFieldSummary[];
+}
+
+export interface ProjectItemResponse {
+  node_id: string;
+  content_type: string;
+  content_number?: number;
+  content_title: string;
+  content_state?: string;
+  content_url?: string;
+  content_repository?: string;
+  field_values?: unknown;
+}
+
+export interface StatusCount {
+  status: string;
+  count: number;
+}
+
+export interface ContentTypeCount {
+  content_type: string;
+  count: number;
+}
+
+export interface ProjectMetrics {
+  project_number: number;
+  project_title: string;
+  total_items: number;
+  by_status: StatusCount[];
+  by_content_type: ContentTypeCount[];
+}
+
 // API Response wrappers
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
## Summary

Adds full GitHub Projects V2 support across all layers of the stack:

- **Phase 8a - GraphQL Client & Models**: New GraphQL client for GitHub Projects V2 API with pagination, org/user fallback queries, null-node handling for partial responses, and comprehensive project/field/item data models
- **Phase 8b - Database & Sync**: SQLite schema (migration 003) for projects, fields, and items with full sync pipeline that fetches via GraphQL and upserts into the database
- **Phase 8c - REST API Endpoints**: Five new API endpoints under `/api/v1/orgs/{org}/projects` for listing projects, project detail, items (paginated with filters), metrics, and an aggregate endpoint across all orgs
- **Phase 8d - Dashboard UI**: Projects list page with dual-mode support (single-org and aggregate), project detail page with GitHub-style Kanban board view, table view toggle, status/content-type charts, filters, and pagination

### Key Features

- Kanban board view grouped by Status field columns (Todo, In Progress, Done, etc.)
- Automatic org-to-user fallback for GitHub accounts that are users, not organizations
- Handles partial GraphQL responses (null nodes) when token lacks `read:project` scope
- Content type and state filters on project items
- Status distribution pie chart and content type bar chart

## Files Changed (23 files, +4045 lines)

| Layer | Files | Description |
|-------|-------|-------------|
| Core models | `models/project.rs` | Project, ProjectField, ProjectItem structs |
| GraphQL client | `client/graphql.rs` | Queries, pagination, org/user fallback |
| Database | `migrations/003_add_projects.sql`, `models.rs`, `queries.rs` | Schema + CRUD operations |
| API routes | `routes/projects.rs`, `main.rs`, `sync.rs` | REST endpoints + sync pipeline |
| Dashboard types | `types/api.ts` | 7 TypeScript interfaces |
| Dashboard API | `lib/api.ts`, `hooks/use-api.ts` | URL builders + 5 SWR hooks |
| Dashboard UI | `app/projects/page.tsx`, `app/projects/[org]/[number]/page.tsx`, `sidebar.tsx` | List page, Kanban detail page, nav item |

## Test plan

- [ ] `cargo build` passes with no errors
- [ ] `cargo test` passes (GraphQL parsing tests updated for Option/null handling)
- [ ] `npm run build` in dashboard passes with no TypeScript errors
- [ ] Projects list loads at `/projects` in both single-org and aggregate modes
- [ ] Clicking a project navigates to detail page with Kanban board view
- [ ] Board/Table view toggle works
- [ ] Content type and state filters work on detail page
- [ ] Charts render status distribution and content type breakdown
- [ ] Sync fetches projects from GitHub for both org and user accounts